### PR TITLE
Refine compile validation & job state

### DIFF
--- a/backend/compile-service/src/compile_service/app/jobs.py
+++ b/backend/compile-service/src/compile_service/app/jobs.py
@@ -5,9 +5,10 @@ import uuid
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
 from enum import Enum
-from typing import Dict, Optional
+from typing import Optional
 
 from .models import CompileRequest
+from .state import add_job
 
 
 class JobStatus(str, Enum):
@@ -29,12 +30,11 @@ class Job:
     logs: Optional[str] = None
 
 
-JOBS: Dict[str, Job] = {}
 JOB_QUEUE: queue.Queue[str] = queue.Queue()
 
 
 def enqueue(req: CompileRequest) -> str:
     job_id = str(uuid.uuid4())
-    JOBS[job_id] = Job(req=req)
+    add_job(job_id, Job(req=req))
     JOB_QUEUE.put(job_id)
     return job_id

--- a/backend/compile-service/src/compile_service/app/models.py
+++ b/backend/compile-service/src/compile_service/app/models.py
@@ -1,13 +1,29 @@
 # backend/compile-service/src/compile_service/app/models.py
 
 from __future__ import annotations
-from pydantic import BaseModel, Field
-from typing import List
+import base64
+from pathlib import Path
+from typing import List, Literal
+
+from pydantic import BaseModel, Field, field_validator, model_validator
+
+from .config import max_upload_bytes
 
 
-class FileIn(BaseModel):
+MAX_BYTES = max_upload_bytes()
+
+
+class FileItem(BaseModel):
     path: str = Field(min_length=1)
     contentBase64: str = Field(min_length=1)
+
+    @field_validator('path')
+    @classmethod
+    def validate_path(cls, v: str) -> str:
+        p = Path(v)
+        if v.startswith('/') or '..' in p.parts:
+            raise ValueError('invalid path')
+        return v
 
 
 class CompileOptions(BaseModel):
@@ -19,9 +35,23 @@ class CompileOptions(BaseModel):
 class CompileRequest(BaseModel):
     projectId: str
     entryFile: str
-    engine: str = 'tectonic'
-    files: List[FileIn]
+    engine: Literal['tectonic'] = 'tectonic'
+    files: List[FileItem]
     options: CompileOptions = Field(default_factory=CompileOptions)
+
+    @model_validator(mode='after')
+    def check_all(self) -> 'CompileRequest':
+        if not any(f.path == self.entryFile for f in self.files):
+            raise ValueError('entryFile not in files')
+        total = 0
+        for f in self.files:
+            try:
+                total += len(base64.b64decode(f.contentBase64, validate=True))
+            except Exception as exc:
+                raise ValueError(f'invalid base64 for {f.path}') from exc
+        if total > MAX_BYTES:
+            raise ValueError('payload too large')
+        return self
 
 
 class CompileResponse(BaseModel):

--- a/backend/compile-service/src/compile_service/app/state.py
+++ b/backend/compile-service/src/compile_service/app/state.py
@@ -1,0 +1,25 @@
+from __future__ import annotations
+
+from typing import Dict, Optional, TYPE_CHECKING
+
+if TYPE_CHECKING:  # pragma: no cover - type hints only
+    from .jobs import Job, JobStatus
+
+JOBS: Dict[str, 'Job'] = {}
+
+
+def add_job(job_id: str, job: 'Job') -> None:
+    JOBS[job_id] = job
+
+
+def get_job(job_id: str) -> Optional['Job']:
+    return JOBS.get(job_id)
+
+
+def update_job_status(job_id: str, status: 'JobStatus', **updates: str | None) -> None:
+    job = JOBS.get(job_id)
+    if not job:
+        return
+    job.status = status
+    for key, value in updates.items():
+        setattr(job, key, value)

--- a/backend/compile-service/src/compile_service/app/worker.py
+++ b/backend/compile-service/src/compile_service/app/worker.py
@@ -10,7 +10,8 @@ from datetime import datetime, timezone
 from pathlib import Path
 
 from .config import artifacts_dir, compile_timeout_seconds
-from .jobs import JOB_QUEUE, JOBS, JobStatus
+from .jobs import JOB_QUEUE, JobStatus
+from .state import get_job, update_job_status
 from .logging import job_id_var
 from .models import CompileOptions
 
@@ -60,13 +61,12 @@ def _run_tectonic(workdir: Path, entry: str, opts: CompileOptions) -> tuple[int,
 
 
 def _compile_job(job_id: str) -> None:
-    job = JOBS.get(job_id)
+    job = get_job(job_id)
     if not job:
         return
 
     token = job_id_var.set(job_id)
-    job.status = JobStatus.RUNNING
-    job.started_at = datetime.now(timezone.utc).isoformat()
+    update_job_status(job_id, JobStatus.RUNNING, started_at=datetime.now(timezone.utc).isoformat())
     logging.info('job started')
 
     with tempfile.TemporaryDirectory(prefix='ctex_') as tmp:

--- a/backend/compile-service/tests/test_validation.py
+++ b/backend/compile-service/tests/test_validation.py
@@ -25,6 +25,7 @@ def test_invalid_engine() -> None:
     with TestClient(app) as client:
         resp = client.post('/compile', json=payload)
     assert resp.status_code == 400
+    assert isinstance(resp.json()['detail'], list)
 
 
 def test_entryfile_missing() -> None:
@@ -33,6 +34,7 @@ def test_entryfile_missing() -> None:
     with TestClient(app) as client:
         resp = client.post('/compile', json=payload)
     assert resp.status_code == 400
+    assert isinstance(resp.json()['detail'], list)
 
 
 def test_invalid_path() -> None:
@@ -41,6 +43,7 @@ def test_invalid_path() -> None:
     with TestClient(app) as client:
         resp = client.post('/compile', json=payload)
     assert resp.status_code == 400
+    assert isinstance(resp.json()['detail'], list)
 
 
 def test_leading_slash_path() -> None:


### PR DESCRIPTION
## Summary
- validate compile requests via Pydantic models
- expose in-memory job table helpers
- surface validation details and payload limit errors
- test validation error details

## Testing
- `make lint`
- `make typecheck`
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_688603f974e483318541d7592e250f94