### PR TITLE
Switch job state to Redis backend

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: up down dev dev-backend dev-collab test lint typecheck fmt check-node
+.PHONY: up down dev dev-backend dev-collab dev-redis test lint typecheck fmt check-node
 
 up:
 	docker compose up --build -d
@@ -17,7 +17,10 @@ dev-backend:
 
 # Collab websocket (pin y-websocket and auto-confirm with -y)
 dev-collab: check-node
-	npx -y y-websocket@1.5.0 --port 1234 --ping-timeout 30000
+        npx -y y-websocket@1.5.0 --port 1234 --ping-timeout 30000
+
+dev-redis:
+        docker run --rm -p 6379:6379 redis:7-alpine
 
 # Always use dev group tools (pytest-xdist, ruff, mypy)
 test:

--- a/backend/compile-service/README.md
+++ b/backend/compile-service/README.md
@@ -14,6 +14,14 @@ Stop with:
 make down
 ```
 
+To test Redis-backed persistence locally:
+
+```bash
+brew install redis  # or use your package manager
+make dev-redis &
+export COLLATEX_STATE=redis
+```
+
 ## Example request
 
 ```bash

--- a/backend/compile-service/pyproject.toml
+++ b/backend/compile-service/pyproject.toml
@@ -13,6 +13,7 @@ dependencies = [
   'python-multipart>=0.0.9',
   'structlog>=24.1.0',
   'prometheus_client>=0.20.0',
+  'redis>=5.0.0',
 ]
 
 [project.optional-dependencies]
@@ -21,6 +22,7 @@ dev = [
   'httpx>=0.27',
   'mypy>=1.10',
   'ruff>=0.5',
+  'fakeredis>=2.24.0',
 ]
 
 [tool.ruff]

--- a/backend/compile-service/src/compile_service/app/jobs.py
+++ b/backend/compile-service/src/compile_service/app/jobs.py
@@ -34,8 +34,8 @@ class Job:
 JOB_QUEUE: queue.Queue[str] = queue.Queue()
 
 
-def enqueue(req: CompileRequest) -> str:
+async def enqueue(req: CompileRequest) -> str:
     job_id = str(uuid.uuid4())
-    add_job(job_id, Job(req=req))
+    await add_job(job_id, Job(req=req))
     JOB_QUEUE.put(job_id)
     return job_id

--- a/backend/compile-service/src/compile_service/app/main.py
+++ b/backend/compile-service/src/compile_service/app/main.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 
 import base64
 from typing import Any, Dict
+import os
+import redis.asyncio as redis
 
 from prometheus_client import make_asgi_app
 
@@ -12,7 +14,7 @@ from fastapi.responses import JSONResponse, Response
 
 from .config import max_upload_bytes
 from .jobs import JobStatus, enqueue
-from .state import get_job
+from .state import get_job, init as state_init
 from ..logging import configure_logging
 from .middleware import RequestIdMiddleware
 from .models import CompileRequest, CompileResponse
@@ -28,8 +30,25 @@ app.mount('/metrics', make_asgi_app(), name='metrics')
 
 
 @app.on_event('startup')
+async def setup_redis() -> None:
+    if os.getenv('COLLATEX_STATE', 'memory') == 'redis':
+        url = os.getenv('REDIS_URL', 'redis://localhost:6379/0')
+        client = redis.from_url(url)  # type: ignore[no-untyped-call]
+        await client.ping()
+        state_init(client)
+        app.state.redis = client
+
+
+@app.on_event('startup')
 def launch_worker() -> None:
     start_worker()
+
+
+@app.on_event('shutdown')
+async def close_redis() -> None:
+    client = getattr(app.state, 'redis', None)
+    if client is not None:
+        await client.close()
 
 
 app.add_middleware(
@@ -70,13 +89,13 @@ async def compile_endpoint(
     req: CompileRequest = Depends(_parse_compile_request),
 ) -> CompileResponse:
     _validate_request(req)
-    job_id = enqueue(req)
+    job_id = await enqueue(req)
     return CompileResponse(jobId=job_id)
 
 
 @app.get('/jobs/{job_id}')
 async def job_status(job_id: str) -> JSONResponse:
-    job = get_job(job_id)
+    job = await get_job(job_id)
     if not job:
         raise HTTPException(status_code=404, detail='job not found')
     body: Dict[str, Any] = {
@@ -96,7 +115,7 @@ async def job_status(job_id: str) -> JSONResponse:
 
 @app.get('/pdf/{job_id}')
 async def get_pdf(job_id: str) -> Response:
-    job = get_job(job_id)
+    job = await get_job(job_id)
     if not job or job.status != JobStatus.DONE or not job.pdf_bytes:
         raise HTTPException(status_code=404, detail='pdf not found')
     return Response(

--- a/backend/compile-service/src/compile_service/app/state_memory.py
+++ b/backend/compile-service/src/compile_service/app/state_memory.py
@@ -1,0 +1,34 @@
+from __future__ import annotations
+
+from typing import Dict, Optional, TYPE_CHECKING
+
+if TYPE_CHECKING:  # pragma: no cover - type hints only
+    from .jobs import Job, JobStatus
+
+JOBS: Dict[str, 'Job'] = {}
+
+
+async def add_job(job_id: str, job: 'Job') -> None:
+    JOBS[job_id] = job
+
+
+async def get_job(job_id: str) -> Optional['Job']:
+    return JOBS.get(job_id)
+
+
+async def update_job_status(job_id: str, status: 'JobStatus', **updates: str | None) -> None:
+    job = JOBS.get(job_id)
+    if not job:
+        return
+    job.status = status
+    for key, value in updates.items():
+        setattr(job, key, value)
+
+
+async def list_jobs() -> Dict[str, 'Job']:
+    return JOBS.copy()
+
+
+def init(_: object | None = None) -> None:
+    """No-op init to match redis backend."""
+    return None

--- a/backend/compile-service/src/compile_service/app/state_redis.py
+++ b/backend/compile-service/src/compile_service/app/state_redis.py
@@ -1,0 +1,89 @@
+from __future__ import annotations
+
+import base64
+from datetime import timedelta
+from typing import Dict, Optional, TYPE_CHECKING, Any, cast
+
+import redis.asyncio as redis
+
+if TYPE_CHECKING:  # pragma: no cover
+    from .jobs import Job, JobStatus
+
+_REDIS: redis.Redis | None = None
+_PREFIX = 'job:'
+_PDF_TTL = timedelta(days=1).seconds
+
+
+def init(client: redis.Redis) -> None:
+    global _REDIS
+    _REDIS = client
+
+
+async def add_job(job_id: str, job: 'Job') -> None:
+    if _REDIS is None:
+        raise RuntimeError('redis not initialized')
+    _ = await cast(Any, _REDIS.hset(
+        f'{_PREFIX}{job_id}',
+        mapping={
+            'status': job.status.value,
+            'queued_at': job.queued_at,
+            'metadata': job.req.model_dump_json(),
+        },
+    ))
+
+
+async def get_job(job_id: str) -> Optional['Job']:
+    if _REDIS is None:
+        raise RuntimeError('redis not initialized')
+    data = await cast(Any, _REDIS.hgetall(f'{_PREFIX}{job_id}'))
+    if not data:
+        return None
+    strmap = {k.decode(): v.decode() for k, v in data.items()}
+    from .models import CompileRequest
+    from .jobs import Job, JobStatus
+
+    req = CompileRequest.model_validate_json(strmap['metadata'])
+    job = Job(
+        req=req,
+        status=JobStatus(strmap['status']),
+        queued_at=strmap['queued_at'],
+        started_at=strmap.get('started_at') or None,
+        finished_at=strmap.get('finished_at') or None,
+        error=strmap.get('error') or None,
+    )
+    pdf = await _REDIS.get(f'{_PREFIX}{job_id}:pdf')
+    if pdf:
+        job.pdf_bytes = base64.b64decode(pdf)
+    return job
+
+
+async def update_job_status(job_id: str, status: 'JobStatus', **updates: str | bytes | None) -> None:
+    if _REDIS is None:
+        raise RuntimeError('redis not initialized')
+    mapping: Dict[str, str] = {'status': status.value}
+    for key in ('started_at', 'finished_at', 'error'):
+        val = updates.get(key)
+        if val is not None:
+            mapping[key] = str(val)
+    if 'metadata' in updates and updates['metadata'] is not None:
+        mapping['metadata'] = str(updates['metadata'])
+    _ = await cast(Any, _REDIS.hset(f'{_PREFIX}{job_id}', mapping=mapping))
+    pdf_bytes = updates.get('pdf_bytes')
+    if pdf_bytes is not None:
+        b64 = base64.b64encode(pdf_bytes if isinstance(pdf_bytes, bytes) else pdf_bytes.encode())
+        _ = await cast(Any, _REDIS.setex(f'{_PREFIX}{job_id}:pdf', _PDF_TTL, b64))
+
+
+async def list_jobs() -> Dict[str, 'Job']:
+    if _REDIS is None:
+        raise RuntimeError('redis not initialized')
+    keys = await _REDIS.keys(f'{_PREFIX}*')
+    result: Dict[str, 'Job'] = {}
+    for key in keys:
+        if key.endswith(b':pdf'):
+            continue
+        job_id = key.decode().split(':', 1)[1]
+        job = await get_job(job_id)
+        if job:
+            result[job_id] = job
+    return result

--- a/backend/compile-service/src/compile_service/app/worker.py
+++ b/backend/compile-service/src/compile_service/app/worker.py
@@ -1,9 +1,12 @@
 from __future__ import annotations
 
 import threading
+import asyncio
 
-from .jobs import JOB_QUEUE
-from .state import get_job
+from datetime import datetime, timezone
+
+from .jobs import JOB_QUEUE, JobStatus
+from .state import get_job, update_job_status
 from structlog.contextvars import bind_contextvars, unbind_contextvars
 
 from ..logging import job_id_var
@@ -11,13 +14,27 @@ from ..executor import run_compile
 
 
 def _compile_job(job_id: str) -> None:
-    job = get_job(job_id)
+    asyncio.run(_compile_job_async(job_id))
+
+
+async def _compile_job_async(job_id: str) -> None:
+    job = await get_job(job_id)
     if not job:
         return
     token = job_id_var.set(job_id)
     bind_contextvars(job_id=job_id)
     try:
+        job.status = JobStatus.RUNNING
+        job.started_at = datetime.now(timezone.utc).isoformat()
+        await update_job_status(job_id, JobStatus.RUNNING, started_at=job.started_at)
         run_compile(job)
+        await update_job_status(
+            job_id,
+            job.status,
+            finished_at=job.finished_at,
+            error=job.error,
+            pdf_bytes=job.pdf_bytes,
+        )
     finally:
         job_id_var.reset(token)
         unbind_contextvars('job_id')

--- a/backend/compile-service/tests/conftest.py
+++ b/backend/compile-service/tests/conftest.py
@@ -1,0 +1,24 @@
+import importlib
+import asyncio
+
+import pytest
+import fakeredis.aioredis
+
+
+@pytest.fixture(params=['memory', 'redis'])
+def app(request, monkeypatch):
+    state_backend = request.param
+    monkeypatch.setenv('COLLATEX_STATE', state_backend)
+    if state_backend == 'redis':
+        redis_server = fakeredis.aioredis.FakeRedis()
+        monkeypatch.setattr('redis.asyncio.Redis.from_url', lambda url: redis_server)
+    import compile_service.app.state as state
+    importlib.reload(state)
+    import compile_service.app.main as main
+    importlib.reload(main)
+    if state_backend == 'redis':
+        state.init(redis_server)
+    yield main.app
+    if state_backend == 'redis':
+        asyncio.run(redis_server.close())
+

--- a/backend/compile-service/tests/test_compile.py
+++ b/backend/compile-service/tests/test_compile.py
@@ -6,11 +6,9 @@ from pathlib import Path
 import pytest
 from fastapi.testclient import TestClient
 
-from compile_service.app.main import app
-
 
 @pytest.mark.skipif(shutil.which('tectonic') is None, reason='tectonic not installed')
-def test_compile_minimal() -> None:
+def test_compile_minimal(app) -> None:
     root = Path(__file__).resolve().parents[3]
     main = (root / 'examples/minimal/main.tex').read_bytes()
     payload = {
@@ -35,7 +33,7 @@ def test_compile_minimal() -> None:
         assert pdf.content.startswith(b'%PDF')
 
 
-def test_invalid_base64() -> None:
+def test_invalid_base64(app) -> None:
     payload = {
         'projectId': 'demo',
         'entryFile': 'main.tex',
@@ -48,7 +46,7 @@ def test_invalid_base64() -> None:
         assert r.status_code == 400
 
 
-def test_oversized_input() -> None:
+def test_oversized_input(app) -> None:
     big = base64.b64encode(b'a' * (2 * 1024 * 1024 + 1)).decode()
     payload = {
         'projectId': 'demo',
@@ -62,7 +60,7 @@ def test_oversized_input() -> None:
         assert r.status_code == 413
 
 
-def test_dangerous_tex() -> None:
+def test_dangerous_tex(app) -> None:
     bad = base64.b64encode(b'\\write18{rm -rf /}').decode()
     payload = {
         'projectId': 'demo',
@@ -77,7 +75,7 @@ def test_dangerous_tex() -> None:
 
 
 @pytest.mark.skipif(shutil.which('tectonic') is None, reason='tectonic not installed')
-def test_compile_error() -> None:
+def test_compile_error(app) -> None:
     bad_tex = base64.b64encode(b'\\documentclass{article}').decode()
     payload = {
         'projectId': 'demo',

--- a/backend/compile-service/tests/test_compile_success.py
+++ b/backend/compile-service/tests/test_compile_success.py
@@ -1,10 +1,8 @@
-import base64
 import shutil
 import time
 import pytest
 from fastapi.testclient import TestClient
-
-from compile_service.app.main import app
+import base64
 
 
 def _minimal_payload(tex: bytes) -> dict:
@@ -18,7 +16,7 @@ def _minimal_payload(tex: bytes) -> dict:
 
 
 @pytest.mark.skipif(shutil.which('tectonic') is None, reason='Tectonic not installed')
-def test_compile_minimal_success() -> None:
+def test_compile_minimal_success(app) -> None:
     tex = b'\\documentclass{article}\\begin{document}ok\\end{document}'
     payload = _minimal_payload(tex)
     with TestClient(app) as client:
@@ -37,7 +35,7 @@ def test_compile_minimal_success() -> None:
 
 
 @pytest.mark.skipif(shutil.which('tectonic') is None, reason='Tectonic not installed')
-def test_compile_timeout() -> None:
+def test_compile_timeout(app) -> None:
     tex = b'\\documentclass{article}\\begin{document}\\loop\\iftrue\\repeat\\end{document}'
     payload = _minimal_payload(tex)
     payload['options']['maxSeconds'] = 1

--- a/backend/compile-service/tests/test_health.py
+++ b/backend/compile-service/tests/test_health.py
@@ -1,8 +1,7 @@
 from fastapi.testclient import TestClient
-from compile_service.app.main import app
 
 
-def test_health() -> None:
+def test_health(app) -> None:
     with TestClient(app) as client:
         resp = client.get('/healthz')
         assert resp.status_code == 200

--- a/backend/compile-service/tests/test_jobs.py
+++ b/backend/compile-service/tests/test_jobs.py
@@ -3,7 +3,6 @@ import shutil
 import time
 import pytest
 from fastapi.testclient import TestClient
-from compile_service.app.main import app
 
 
 def payload() -> dict:
@@ -21,7 +20,7 @@ def payload() -> dict:
     }
 
 
-def test_job_lifecycle() -> None:
+def test_job_lifecycle(app) -> None:
     if shutil.which('tectonic') is None:
         pytest.skip('tectonic not installed')
     with TestClient(app) as client:

--- a/backend/compile-service/tests/test_logging.py
+++ b/backend/compile-service/tests/test_logging.py
@@ -3,10 +3,8 @@ import logging
 
 from fastapi.testclient import TestClient
 
-from compile_service.app.main import app
 
-
-def test_request_id_logging(caplog) -> None:
+def test_request_id_logging(app, caplog) -> None:
     caplog.set_level(logging.INFO)
     with TestClient(app) as client:
         client.get('/healthz', headers={'X-Request-Id': 'test-123'})

--- a/backend/compile-service/tests/test_metrics.py
+++ b/backend/compile-service/tests/test_metrics.py
@@ -5,8 +5,6 @@ import time
 import pytest
 from fastapi.testclient import TestClient
 
-from compile_service.app.main import app
-
 
 def _payload() -> dict:
     tex = b'\\documentclass{article}\\begin{document}ok\\end{document}'
@@ -20,7 +18,7 @@ def _payload() -> dict:
 
 
 @pytest.mark.skipif(shutil.which('tectonic') is None, reason='Tectonic not installed')
-def test_compile_metrics() -> None:
+def test_compile_metrics(app) -> None:
     with TestClient(app) as client:
         resp = client.post('/compile', json=_payload())
         assert resp.status_code == 202

--- a/backend/compile-service/tests/test_pdf.py
+++ b/backend/compile-service/tests/test_pdf.py
@@ -3,7 +3,6 @@ import time
 import shutil
 import pytest
 from fastapi.testclient import TestClient
-from compile_service.app.main import app
 
 
 def payload() -> dict:
@@ -23,7 +22,7 @@ def payload() -> dict:
     }
 
 
-def test_pdf_generated() -> None:
+def test_pdf_generated(app) -> None:
     if shutil.which('tectonic') is None:
         pytest.skip('tectonic not installed')
     with TestClient(app) as client:

--- a/backend/compile-service/tests/test_security.py
+++ b/backend/compile-service/tests/test_security.py
@@ -1,6 +1,5 @@
 import base64
 from fastapi.testclient import TestClient
-from compile_service.app.main import app
 
 
 def minimal_payload() -> dict:
@@ -18,7 +17,7 @@ def minimal_payload() -> dict:
     }
 
 
-def test_write18_rejected() -> None:
+def test_write18_rejected(app) -> None:
     payload = minimal_payload()
     payload['files'][0]['contentBase64'] = base64.b64encode(b'\\write18{ls}').decode()
     with TestClient(app) as client:

--- a/backend/compile-service/tests/test_state_redis.py
+++ b/backend/compile-service/tests/test_state_redis.py
@@ -1,0 +1,54 @@
+import asyncio
+import importlib
+
+import fakeredis.aioredis
+import pytest
+
+from compile_service.app import state
+from compile_service.app.jobs import Job, JobStatus
+from compile_service.app.models import CompileRequest, FileItem, CompileOptions
+
+
+@pytest.fixture
+def redis_server():
+    server = fakeredis.aioredis.FakeRedis()
+    yield server
+    asyncio.run(server.close())
+
+
+@pytest.fixture(autouse=True)
+def setup_state(monkeypatch, redis_server):
+    monkeypatch.setenv('COLLATEX_STATE', 'redis')
+    importlib.reload(state)
+    state.init(redis_server)
+
+
+def _job() -> Job:
+    req = CompileRequest(
+        projectId='x',
+        entryFile='main.tex',
+        files=[FileItem(path='main.tex', contentBase64='YQ==')],
+        options=CompileOptions(),
+    )
+    return Job(req=req)
+
+
+def test_round_trip(redis_server):
+    job = _job()
+    asyncio.run(state.add_job('1', job))
+    other = asyncio.run(state.get_job('1'))
+    assert other == job
+
+
+def test_update_visible_across_instances(redis_server):
+    job = _job()
+    asyncio.run(state.add_job('2', job))
+    asyncio.run(state.update_job_status('2', JobStatus.DONE, finished_at='now'))
+
+    importlib.reload(state)
+    state.init(redis_server)
+
+    again = asyncio.run(state.get_job('2'))
+    assert again.finished_at == 'now'
+    assert again.status == JobStatus.DONE
+


### PR DESCRIPTION
## Summary
- add redis and fakeredis dependencies
- introduce async Redis state backend
- inject Redis connection via FastAPI events
- update worker and endpoints for async state
- parametrize tests for memory and redis backends
- add redis dev target and docs

## Testing
- `ruff check .`
- `mypy src`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68862d468aac8331bf3edb3d53865243