### PR TITLE
Add CI workflow and Redis-aware tests

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,0 +1,29 @@
+name: CollaTeX CI
+on: [push, pull_request]
+jobs:
+  backend:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: [3.11, 3.12]
+        state: [memory, redis]
+    env:
+      COLLATEX_STATE: ${{ matrix.state }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Install uv
+        run: pip install uv
+      - name: Install deps
+        run: uv pip install -e backend/compile-service[dev]
+      - name: Start Redis (if needed)
+        if: matrix.state == 'redis'
+        run: docker run -d -p 6379:6379 redis:7-alpine
+      - name: Lint
+        run: make lint
+      - name: Type-check
+        run: make typecheck
+      - name: Tests
+        run: make test

--- a/Makefile
+++ b/Makefile
@@ -27,6 +27,9 @@ dev-worker:
 
 # Always use dev group tools (pytest-xdist, ruff, mypy)
 test:
+	if [ "$$COLLATEX_STATE" = "redis" ]; then \
+	python scripts/check_redis.py; \
+	fi
 	cd backend/compile-service && uv run --extra dev -m pytest -n auto -q
 
 lint:

--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+[![CI](https://github.com/ikanher/collatex/actions/workflows/ci.yaml/badge.svg)](https://github.com/ikanher/collatex/actions/workflows/ci.yaml)
 AGENTS
 
 ## 1) Architect

--- a/backend/compile-service/pyproject.toml
+++ b/backend/compile-service/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "uv_build"
 [project]
 name = 'compile_service'
 version = '0.1.0'
-requires-python = '>=3.12'
+requires-python = '>=3.11'
 dependencies = [
   'fastapi>=0.111',
   'uvicorn>=0.30',

--- a/backend/compile-service/tests/conftest.py
+++ b/backend/compile-service/tests/conftest.py
@@ -2,7 +2,9 @@ import importlib
 import asyncio
 
 import pytest
-import fakeredis.aioredis
+import os
+import redis.asyncio as redis
+from .helpers import require_redis
 
 
 @pytest.fixture(params=['memory', 'redis'])
@@ -10,18 +12,21 @@ def app(request, monkeypatch):
     state_backend = request.param
     monkeypatch.setenv('COLLATEX_STATE', state_backend)
     if state_backend == 'redis':
-        redis_server = fakeredis.aioredis.FakeRedis()
-        monkeypatch.setattr('redis.asyncio.Redis.from_url', lambda url: redis_server)
+        require_redis()
+        url = os.getenv('REDIS_URL', 'redis://localhost:6379/0')
+        redis_server = redis.from_url(url)
+        monkeypatch.setattr('redis.asyncio.Redis.from_url', lambda url=url: redis_server)
     import compile_service.app.state as state
+
     importlib.reload(state)
     import compile_service.app.main as main
+
     importlib.reload(main)
     if state_backend == 'redis':
         state.init(redis_server)
     yield main.app
     if state_backend == 'redis':
-        asyncio.run(redis_server.close())
+        asyncio.run(redis_server.aclose())
     stop = getattr(main.app.state, 'worker_stop', None)
     if stop is not None:
         stop()
-

--- a/backend/compile-service/tests/helpers.py
+++ b/backend/compile-service/tests/helpers.py
@@ -1,0 +1,20 @@
+from __future__ import annotations
+
+import os
+import socket
+import urllib.parse
+
+import pytest
+
+
+def require_redis() -> None:
+    """Skip tests if Redis isn't reachable."""
+    url = os.getenv('REDIS_URL', 'redis://localhost:6379/0')
+    parsed = urllib.parse.urlparse(url)
+    host = parsed.hostname or 'localhost'
+    port = parsed.port or 6379
+    try:
+        with socket.create_connection((host, port), timeout=1):
+            return
+    except OSError:
+        pytest.skip('Redis not available', allow_module_level=True)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ readme = "README.md"
 authors = [
     { name = "Aki Rehn", email = "aki@rehn.fi" }
 ]
-requires-python = ">=3.12"
+requires-python = ">=3.11"
 dependencies = []
 
 [build-system]

--- a/scripts/check_redis.py
+++ b/scripts/check_redis.py
@@ -1,0 +1,14 @@
+import os
+import socket
+import sys
+import urllib.parse
+
+url = os.getenv("REDIS_URL", "redis://localhost:6379/0")
+parts = urllib.parse.urlparse(url)
+host = parts.hostname or "localhost"
+port = parts.port or 6379
+try:
+    socket.create_connection((host, port), timeout=1).close()
+except OSError:
+    print(f"Redis not reachable at {host}:{port}", file=sys.stderr)
+    sys.exit(1)


### PR DESCRIPTION
## Summary
- add GitHub Actions workflow `ci.yaml`
- show CI badge in README
- update python compatibility to 3.11+
- ensure `make test` checks Redis availability
- add helper to skip Redis tests when Redis not running
- update tests to use real Redis when available
- add connectivity check script

## Testing
- `make lint`
- `make typecheck`
- `make test`
- `COLLATEX_STATE=redis make test` *(fails when Redis unavailable)*

------
https://chatgpt.com/codex/tasks/task_e_688647725a988331a8ad2b28182c0921