### PR TITLE
Add compose launcher and smoke test

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -59,3 +59,14 @@ jobs:
         run: |
           npm run lint --workspace apps/frontend
           npm run test --workspace apps/frontend
+  e2e:
+    if: >-
+      github.event_name == 'schedule' ||
+      (github.event_name == 'push' && github.ref == 'refs/heads/main')
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Start stack
+        run: docker compose up -d --build
+      - name: Run smoke test
+        run: ./scripts/smoke.sh

--- a/README.md
+++ b/README.md
@@ -48,27 +48,18 @@ Tasks:
 
 ## Dev loop
 ```bash
-# run full stack
-make dev-redis & \\
-make dev-worker & \\
-make dev-backend & \\
-make dev-collab & \\
-make dev-frontend
+# Quick start
+docker compose up --build
+./scripts/smoke.sh
+open http://localhost:5173
 ```
 
-Set `ALLOWED_ORIGINS` to comma-separated hosts for CORS.
-
-### Frontend
-
+## Architecture
+```mermaid
+graph TD
+  browser[Browser] <--> frontend[Frontend]
+  frontend <--> gateway[Gateway]
+  gateway <--> redis[(Redis)]
+  redis <--> backend[Backend]
+  redis <--> worker[Worker]
 ```
-VITE_API_URL=http://localhost:8080
-VITE_WS_URL=ws://localhost:1234
-```
-
-Start the SPA:
-
-```bash
-npm run dev --workspace apps/frontend
-```
-
-Then open http://localhost:5173.

--- a/apps/collab_gateway/Dockerfile
+++ b/apps/collab_gateway/Dockerfile
@@ -1,0 +1,6 @@
+FROM node:20-alpine
+WORKDIR /app
+COPY . .
+RUN npm ci --omit=dev && npm run build
+CMD ["node", "dist/index.js"]
+

--- a/apps/frontend/Dockerfile
+++ b/apps/frontend/Dockerfile
@@ -1,0 +1,8 @@
+FROM node:20-alpine AS build
+WORKDIR /app
+COPY . .
+RUN npm ci --omit=dev && npm run build
+FROM nginx:1.27-alpine
+COPY --from=build /app/dist /usr/share/nginx/html
+EXPOSE 80
+

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,10 +1,26 @@
-version: '3'
+version: "3.9"
 services:
-  compile-service:
-    build: .
-    ports:
-      - "8000:8000"
-    volumes:
-      - .:/app
-    working_dir: /app/backend/compile-service
-    command: uvicorn compile_service.app.main:app --host 0.0.0.0 --port 8000
+  redis:
+    image: redis:7-alpine
+  backend:
+    build: ./backend/compile-service
+    environment:
+      COLLATEX_STATE: redis
+      REDIS_URL: redis://redis:6379
+    ports: ["8080:8080"]
+  worker:
+    build: ./backend/compile-service
+    entrypoint: ["uv", "run", "compile_service.worker:main"]
+    environment:
+      COLLATEX_STATE: redis
+      REDIS_URL: redis://redis:6379
+  gateway:
+    build: ./apps/collab_gateway
+    environment:
+      PORT: 1234
+      ALLOWED_ORIGINS: localhost
+    ports: ["1234:1234"]
+  frontend:
+    build: ./apps/frontend
+    ports: ["5173:80"]
+


### PR DESCRIPTION
## Summary
- add Dockerfiles for gateway and frontend apps
- create docker-compose stack for the whole system
- implement `scripts/smoke.sh` for end-to-end check
- wire smoke test into CI as nightly/main `e2e` job
- streamline README with quick start and architecture diagram

## Testing
- `uv run --extra dev ruff check .`
- `uv run --extra dev mypy -p compile_service`
- `uv run --extra dev -m pytest -n auto -q`
- `./scripts/smoke.sh` *(fails: Timed out waiting for http://localhost:8080/healthz)*

------
https://chatgpt.com/codex/tasks/task_e_6886677482b08331b240c699938fec32