### PR TITLE
Expose compile logs in UI

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,3 +69,8 @@ graph TD
 Set `COLLATEX_API_TOKEN` in your `.env` and pass the same value in the frontend
 settings dialog. The compile API expects `Authorization: Bearer <token>` and the
 WebSocket URL must include `token=<token>`.
+
+## Troubleshooting
+
+If a compile fails, open the **Build Log** panel under the PDF viewer. It
+captures the last part of the Tectonic output so you can spot LaTeX errors.

--- a/apps/frontend/src/api/compile.ts
+++ b/apps/frontend/src/api/compile.ts
@@ -12,9 +12,9 @@ export async function startCompile(tex: string): Promise<string> {
   return res.data.jobId as string;
 }
 
-export async function pollJob(jobId: string): Promise<{ status: CompileStatus }> {
+export async function pollJob(jobId: string): Promise<{ status: CompileStatus; log?: string }> {
   const res = await api.get(`/jobs/${jobId}`);
-  return res.data as { status: CompileStatus };
+  return res.data as { status: CompileStatus; log?: string };
 }
 
 export async function fetchPdf(jobId: string): Promise<Blob> {

--- a/apps/frontend/src/components/BuildLog.tsx
+++ b/apps/frontend/src/components/BuildLog.tsx
@@ -1,0 +1,30 @@
+import React from 'react';
+import type { CompileStatus } from '../api/compile';
+
+interface Props {
+  log: string | null;
+  status: CompileStatus | 'idle';
+  open: boolean;
+  onToggle: () => void;
+}
+
+const BuildLog: React.FC<Props> = ({ log, status, open, onToggle }) => {
+  return (
+    <div className="absolute bottom-0 left-0 right-0 bg-gray-50 border-t border-gray-300">
+      <button className="w-full text-left px-2 py-1 bg-gray-200" onClick={onToggle}>
+        Build Log {open ? '▼' : '▲'}
+      </button>
+      {open && (
+        <div className="p-2 font-mono text-sm overflow-y-auto max-h-64">
+          {status === 'running' || status === 'queued' ? (
+            <span>Compiling...</span>
+          ) : (
+            <pre>{log}</pre>
+          )}
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default BuildLog;

--- a/apps/frontend/src/components/EditorPage.tsx
+++ b/apps/frontend/src/components/EditorPage.tsx
@@ -4,12 +4,17 @@ import CompileButton from './CompileButton';
 import PdfViewer from './PdfViewer';
 import Toast from './Toast';
 import SettingsModal from './SettingsModal';
+import BuildLog from './BuildLog';
+import type { CompileStatus } from '../api/compile';
 
 const ROOM = 'main';
 
 const EditorPage: React.FC = () => {
   const [pdfUrl, setPdfUrl] = useState<string | null>(null);
   const [toast, setToast] = useState<string | null>(null);
+  const [log, setLog] = useState<string | null>(null);
+  const [status, setStatus] = useState<'idle' | CompileStatus>('idle');
+  const [logOpen, setLogOpen] = useState(false);
   const [settingsOpen, setSettingsOpen] = useState(false);
 
   return (
@@ -20,7 +25,24 @@ const EditorPage: React.FC = () => {
       <div className="w-1/2 h-full">
         <PdfViewer pdfUrl={pdfUrl} />
       </div>
-      <CompileButton room={ROOM} onPdf={setPdfUrl} onToast={setToast} />
+      <CompileButton
+        room={ROOM}
+        onPdf={setPdfUrl}
+        onToast={setToast}
+        onLog={(l) => setLog(l)}
+        onStatus={(s) => {
+          setStatus(s);
+          if (s === 'queued' || s === 'running') {
+            setLogOpen(true);
+          }
+          if (s === 'done') {
+            setLogOpen(false);
+          }
+          if (s === 'error') {
+            setLogOpen(true);
+          }
+        }}
+      />
       <Toast message={toast} />
       <button
         className="absolute top-2 right-2 bg-gray-200 px-2 py-1"
@@ -29,6 +51,7 @@ const EditorPage: React.FC = () => {
         Settings
       </button>
       <SettingsModal open={settingsOpen} onClose={() => setSettingsOpen(false)} />
+      <BuildLog log={log} status={status} open={logOpen} onToggle={() => setLogOpen(!logOpen)} />
     </div>
   );
 };

--- a/backend/compile-service/src/compile_service/app/jobs.py
+++ b/backend/compile-service/src/compile_service/app/jobs.py
@@ -28,7 +28,7 @@ class Job:
     error: Optional[str] = None
     pdf_bytes: Optional[bytes] = None
     pdf_path: Optional[str] = None
-    logs: Optional[str] = None
+    compile_log: Optional[str] = None
 
 
 async def enqueue(req: CompileRequest) -> str:

--- a/backend/compile-service/src/compile_service/app/main.py
+++ b/backend/compile-service/src/compile_service/app/main.py
@@ -128,8 +128,8 @@ async def job_status(job_id: str) -> JSONResponse:
         'finishedAt': job.finished_at,
         'error': job.error,
     }
-    if job.logs:
-        body['logs'] = job.logs
+    if job.compile_log and job.status in {JobStatus.ERROR, JobStatus.DONE}:
+        body['log'] = job.compile_log
     if job.pdf_bytes:
         body['pdfUrl'] = f'/pdf/{job_id}'
     return JSONResponse(content=body)

--- a/backend/compile-service/src/compile_service/app/state_redis.py
+++ b/backend/compile-service/src/compile_service/app/state_redis.py
@@ -50,6 +50,7 @@ async def get_job(job_id: str) -> Optional['Job']:
         started_at=strmap.get('started_at') or None,
         finished_at=strmap.get('finished_at') or None,
         error=strmap.get('error') or None,
+        compile_log=strmap.get('log') or None,
     )
     pdf = await _REDIS.get(f'{_PREFIX}{job_id}:pdf')
     if pdf:
@@ -65,6 +66,8 @@ async def update_job_status(job_id: str, status: 'JobStatus', **updates: str | b
         val = updates.get(key)
         if val is not None:
             mapping[key] = str(val)
+    if 'compile_log' in updates and updates['compile_log'] is not None:
+        mapping['log'] = str(updates['compile_log'])
     if 'metadata' in updates and updates['metadata'] is not None:
         mapping['metadata'] = str(updates['metadata'])
     _ = await cast(Any, _REDIS.hset(f'{_PREFIX}{job_id}', mapping=mapping))

--- a/backend/compile-service/src/compile_service/executor.py
+++ b/backend/compile-service/src/compile_service/executor.py
@@ -70,7 +70,8 @@ def run_compile(job: Job) -> None:
                 job.status = JobStatus.ERROR
                 job.error = 'timeout'
             else:
-                job.logs = (stdout + stderr).decode(errors='replace')
+                combined = (stdout + stderr).decode(errors='replace')
+                job.compile_log = combined[-32_000:]
                 if proc.returncode == 0:
                     pdf_path = out_dir / (Path(job.req.entryFile).stem + '.pdf')
                     if pdf_path.exists():

--- a/backend/compile-service/src/compile_service/worker.py
+++ b/backend/compile-service/src/compile_service/worker.py
@@ -52,6 +52,7 @@ async def _process(item: Dict[str, Any]) -> None:
             finished_at=job.finished_at,
             error=job.error,
             pdf_bytes=job.pdf_bytes,
+            compile_log=job.compile_log,
         )
         result = _result_label(job.status, job.error)
         WORKER_COUNTER.labels(result=result).inc()

--- a/backend/compile-service/tests/test_compile.py
+++ b/backend/compile-service/tests/test_compile.py
@@ -93,4 +93,4 @@ def test_compile_error(app) -> None:
                 break
             time.sleep(0.2)
         assert resp.json()['status'] == 'error'
-        assert resp.json()['logs']
+        assert resp.json()['log']

--- a/backend/compile-service/tests/test_logs.py
+++ b/backend/compile-service/tests/test_logs.py
@@ -1,0 +1,28 @@
+import base64
+import shutil
+import time
+import pytest
+from fastapi.testclient import TestClient
+
+
+@pytest.mark.skipif(shutil.which('tectonic') is None, reason='tectonic not installed')
+def test_error_log_exposed(app) -> None:
+    bad_tex = base64.b64encode(b'\\documentclass{article}\n\\begin{document}\n\\textbf{broken}\n').decode()
+    payload = {
+        'projectId': 'demo',
+        'entryFile': 'main.tex',
+        'engine': 'tectonic',
+        'files': [{'path': 'main.tex', 'contentBase64': bad_tex}],
+        'options': {'maxSeconds': 5},
+    }
+    with TestClient(app) as client:
+        r = client.post('/compile', json=payload)
+        job_id = r.json()['jobId']
+        for _ in range(30):
+            resp = client.get(f'/jobs/{job_id}')
+            if resp.json()['status'] in {'done', 'error'}:
+                break
+            time.sleep(0.2)
+        data = resp.json()
+        assert data['status'] == 'error'
+        assert 'error:' in data.get('log', '')


### PR DESCRIPTION
## Summary
- store compile logs on job in executor
- expose log via `/jobs/{id}`
- display logs in new Build Log panel in frontend
- update compile flow test and add log tests
- document Build Log in README

## Testing
- `ruff check backend/compile-service/src apps/frontend/src`
- `mypy backend/compile-service/src/compile_service`
- `npm run lint --prefix apps/frontend`
- `npx vitest run --prefix apps/frontend`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68867173c9048331be0db98282eb79e3