### PR TITLE
Enable CORS config and PDF preview

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,9 @@ docker compose up --build
 ./scripts/smoke.sh
 open http://localhost:5173
 ```
+Do **not** open `index.html` directly with `file://`. Always run `npm run dev` or
+use the Dockerised frontend at `http://localhost:5173` so CORS and relative paths
+work correctly.
 
 ## Architecture
 ```mermaid
@@ -69,6 +72,10 @@ graph TD
 Set `COLLATEX_API_TOKEN` in your `.env` and pass the same value in the frontend
 settings dialog. The compile API expects `Authorization: Bearer <token>` and the
 WebSocket URL must include `token=<token>`.
+
+`COLLATEX_ALLOWED_ORIGINS` controls which frontend URLs may access the backend.
+The default is `http://localhost:5173`. Set it to a comma-separated list of
+origins when deploying.
 
 ## Troubleshooting
 

--- a/apps/frontend/package-lock.json
+++ b/apps/frontend/package-lock.json
@@ -16,6 +16,7 @@
         "pdfjs-dist": "^3.11.174",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
+        "react-pdf": "^10.0.1",
         "y-codemirror.next": "^0.3.5",
         "y-presence": "^0.2.3",
         "y-websocket": "^1.5.0",
@@ -1207,6 +1208,191 @@
       "integrity": "sha512-l0h88YhZFyKdXIFNfSWpyjStDjGHwZ/U7iobcK1cQQD8sejsONdQtTVU+1wVN1PBw40PiiHB1vA5S7VTfQiP9g==",
       "license": "MIT"
     },
+    "node_modules/@napi-rs/canvas": {
+      "version": "0.1.74",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas/-/canvas-0.1.74.tgz",
+      "integrity": "sha512-pOIyzuS+5Bz1vAhD7tdhaw5/936mMJZUn4aVajojUdjYOGSWmfpDYSgt0nQLZPZVN5GLgWgutqXPOi7Jsm3k+Q==",
+      "license": "MIT",
+      "optional": true,
+      "workspaces": [
+        "e2e/*"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "optionalDependencies": {
+        "@napi-rs/canvas-android-arm64": "0.1.74",
+        "@napi-rs/canvas-darwin-arm64": "0.1.74",
+        "@napi-rs/canvas-darwin-x64": "0.1.74",
+        "@napi-rs/canvas-linux-arm-gnueabihf": "0.1.74",
+        "@napi-rs/canvas-linux-arm64-gnu": "0.1.74",
+        "@napi-rs/canvas-linux-arm64-musl": "0.1.74",
+        "@napi-rs/canvas-linux-riscv64-gnu": "0.1.74",
+        "@napi-rs/canvas-linux-x64-gnu": "0.1.74",
+        "@napi-rs/canvas-linux-x64-musl": "0.1.74",
+        "@napi-rs/canvas-win32-x64-msvc": "0.1.74"
+      }
+    },
+    "node_modules/@napi-rs/canvas-android-arm64": {
+      "version": "0.1.74",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-android-arm64/-/canvas-android-arm64-0.1.74.tgz",
+      "integrity": "sha512-aq5ode+9Z/ZR0H485dI2jdRdttg/hl9Ob+iPCt0nj+QFiirpxDrbUHKeTZWQWEtkWyC7vI5R2dMTbDINBfl9eg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@napi-rs/canvas-darwin-arm64": {
+      "version": "0.1.74",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-darwin-arm64/-/canvas-darwin-arm64-0.1.74.tgz",
+      "integrity": "sha512-eO5Miz+ef1dEQyUMWDdcbAb1Wr7yMyxD9/CL9d4frQxO4pTTaCiMBUWup8XDPLr/g7XkSkGCZLP47xiXiyXSpQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@napi-rs/canvas-darwin-x64": {
+      "version": "0.1.74",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-darwin-x64/-/canvas-darwin-x64-0.1.74.tgz",
+      "integrity": "sha512-0EkO0IFkps7C3JpKC7lbM3IL+QDUYeUKagHLDbUry4PeQTghxp6JcgccpmU32ZbpFZgPnm7o0tTJO0J1d8S2rA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@napi-rs/canvas-linux-arm-gnueabihf": {
+      "version": "0.1.74",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-arm-gnueabihf/-/canvas-linux-arm-gnueabihf-0.1.74.tgz",
+      "integrity": "sha512-qAVJEN2JqGayEI1kSpJy1Xr6ZmCFV9QhRyV35yWsS7e9X1jm+T4DAlCxI4PlKIlqVSzYMYhKrxchST20XBSzHg==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@napi-rs/canvas-linux-arm64-gnu": {
+      "version": "0.1.74",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-arm64-gnu/-/canvas-linux-arm64-gnu-0.1.74.tgz",
+      "integrity": "sha512-lOnop22qy6MYxI94GGunMMjo6D80I//2W/6pqKUfwXaDQtOfvHsTcVVzDu5cFXUTNrb9ZRfMCeol5YEd+9FJvg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@napi-rs/canvas-linux-arm64-musl": {
+      "version": "0.1.74",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-arm64-musl/-/canvas-linux-arm64-musl-0.1.74.tgz",
+      "integrity": "sha512-tfFqLHGtSEabBigOnPUfZviSTGmW2xHv5tYZYPBWmgGiTkoNJ7lEWFUxHjwvV5HXGqLs8ok/O7g1enSpxO6lmQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@napi-rs/canvas-linux-riscv64-gnu": {
+      "version": "0.1.74",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-riscv64-gnu/-/canvas-linux-riscv64-gnu-0.1.74.tgz",
+      "integrity": "sha512-j6H9dHTMtr1y3tu/zGm1ythYIL9vTl4EEv9f6CMx0n3Zn2M+OruUUwh9ylCj4afzSNEK9T8cr6zMnmTPzkpBvQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@napi-rs/canvas-linux-x64-gnu": {
+      "version": "0.1.74",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-x64-gnu/-/canvas-linux-x64-gnu-0.1.74.tgz",
+      "integrity": "sha512-73DIV4E7Y9CpIJuUXVl9H6+MEQXyRy4VJQoUGA1tOlcKQiStxqhq6UErL4decI28NxjyQXBhtYZKj5q8AJEuOg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@napi-rs/canvas-linux-x64-musl": {
+      "version": "0.1.74",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-x64-musl/-/canvas-linux-x64-musl-0.1.74.tgz",
+      "integrity": "sha512-FgDMEFdGIJT3I2xejflRJ82/ZgDphyirS43RgtoLaIXI6zihLiZcQ7rczpqeWgAwlJNjR0He2EustsKe1SkUOg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@napi-rs/canvas-win32-x64-msvc": {
+      "version": "0.1.74",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-win32-x64-msvc/-/canvas-win32-x64-msvc-0.1.74.tgz",
+      "integrity": "sha512-x6bhwlhn0wU7dfiP46mt5Bi6PowSUH4CJ4PTzGj58LRQ1HVasEIJgoMx7MLC48F738eJpzbfg3WR/D8+e9CeTA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
@@ -1686,14 +1872,14 @@
       "version": "15.7.15",
       "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.15.tgz",
       "integrity": "sha512-F6bEyamV9jKGAFBEmlQnesRPGOQqS2+Uwi0Em15xenOxHaf2hv6L8YCVn3rPdPJOiJfPiCnLIRyvwVaqMY3MIw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/@types/react": {
       "version": "18.3.23",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.23.tgz",
       "integrity": "sha512-/LDXMQh55EzZQ0uVAZmKKhfENivEvWz6E+EYzh+/MCjMhNsotd+ZHhBGIjFDTi6+fz0OhQQQLbTgdQIxxCsC0w==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@types/prop-types": "*",
@@ -2832,6 +3018,15 @@
       "optional": true,
       "peer": true
     },
+    "node_modules/clsx": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
+      "integrity": "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/codemirror-lang-latex": {
       "version": "0.1.0-alpha.2",
       "resolved": "https://registry.npmjs.org/codemirror-lang-latex/-/codemirror-lang-latex-0.1.0-alpha.2.tgz",
@@ -2965,7 +3160,7 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
       "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/data-urls": {
@@ -3210,6 +3405,15 @@
       "integrity": "sha512-bd2L678uiWATM6m5Z1VzNCErI3jiGzt6HGY8OVICs40JQq/HALfbyNJmp0UDakEY4pMMaN0Ly5om/B1VI/+xfQ==",
       "license": "MIT",
       "optional": true
+    },
+    "node_modules/dequal": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
+      "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
     },
     "node_modules/detect-libc": {
       "version": "2.0.4",
@@ -5589,6 +5793,15 @@
         "@jridgewell/sourcemap-codec": "^1.5.0"
       }
     },
+    "node_modules/make-cancellable-promise": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/make-cancellable-promise/-/make-cancellable-promise-2.0.0.tgz",
+      "integrity": "sha512-3SEQqTpV9oqVsIWqAcmDuaNeo7yBO3tqPtqGRcKkEo0lrzD3wqbKG9mkxO65KoOgXqj+zH2phJ2LiAsdzlogSw==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/wojtekmaj/make-cancellable-promise?sponsor=1"
+      }
+    },
     "node_modules/make-dir": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-3.1.0.tgz",
@@ -5605,6 +5818,15 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/make-event-props": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/make-event-props/-/make-event-props-2.0.0.tgz",
+      "integrity": "sha512-G/hncXrl4Qt7mauJEXSg3AcdYzmpkIITTNl5I+rH9sog5Yw0kK6vseJjCaPfOXqOqQuPUP89Rkhfz5kPS8ijtw==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/wojtekmaj/make-event-props?sponsor=1"
+      }
+    },
     "node_modules/math-intrinsics": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
@@ -5612,6 +5834,23 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/merge-refs": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/merge-refs/-/merge-refs-2.0.0.tgz",
+      "integrity": "sha512-3+B21mYK2IqUWnd2EivABLT7ueDhb0b8/dGK8LoFQPrU61YITeCMn14F7y7qZafWNZhUEKb24cJdiT5Wxs3prg==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/wojtekmaj/merge-refs?sponsor=1"
+      },
+      "peerDependencies": {
+        "@types/react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
       }
     },
     "node_modules/merge-stream": {
@@ -6726,6 +6965,47 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/react-pdf": {
+      "version": "10.0.1",
+      "resolved": "https://registry.npmjs.org/react-pdf/-/react-pdf-10.0.1.tgz",
+      "integrity": "sha512-dblLZ5BqubeNFZwTzHkRi7Rexev2+Xb9z7sEvNYT+IOxmih1KgrByeqD4Hm0RnwR9nTWludXbiHQMe9d47DK2w==",
+      "license": "MIT",
+      "dependencies": {
+        "clsx": "^2.0.0",
+        "dequal": "^2.0.3",
+        "make-cancellable-promise": "^2.0.0",
+        "make-event-props": "^2.0.0",
+        "merge-refs": "^2.0.0",
+        "pdfjs-dist": "5.3.31",
+        "tiny-invariant": "^1.0.0",
+        "warning": "^4.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/wojtekmaj/react-pdf?sponsor=1"
+      },
+      "peerDependencies": {
+        "@types/react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/react-pdf/node_modules/pdfjs-dist": {
+      "version": "5.3.31",
+      "resolved": "https://registry.npmjs.org/pdfjs-dist/-/pdfjs-dist-5.3.31.tgz",
+      "integrity": "sha512-EhPdIjNX0fcdwYQO+e3BAAJPXt+XI29TZWC7COhIXs/K0JHcUt1Gdz1ITpebTwVMFiLsukdUZ3u0oTO7jij+VA==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=20.16.0 || >=22.3.0"
+      },
+      "optionalDependencies": {
+        "@napi-rs/canvas": "^0.1.67"
+      }
+    },
     "node_modules/react-refresh": {
       "version": "0.17.0",
       "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.17.0.tgz",
@@ -7627,6 +7907,12 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/tiny-invariant": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/tiny-invariant/-/tiny-invariant-1.3.3.tgz",
+      "integrity": "sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg==",
+      "license": "MIT"
+    },
     "node_modules/tinybench": {
       "version": "2.9.0",
       "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
@@ -8118,6 +8404,15 @@
       },
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/warning": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/warning/-/warning-4.0.3.tgz",
+      "integrity": "sha512-rpJyN222KWIvHJ/F53XSZv0Zl/accqHR8et1kpaMTD/fLCRxtV8iX8czMzY7sVZupTI3zcUTg8eycS2kNF9l6w==",
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.0.0"
       }
     },
     "node_modules/webidl-conversions": {

--- a/apps/frontend/package.json
+++ b/apps/frontend/package.json
@@ -11,6 +11,7 @@
   "dependencies": {
     "axios": "^1.6.8",
     "pdfjs-dist": "^3.11.174",
+    "react-pdf": "^10.0.1",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "yjs": "^13.6.12",

--- a/apps/frontend/src/components/CompileButton.tsx
+++ b/apps/frontend/src/components/CompileButton.tsx
@@ -4,7 +4,7 @@ import { useCollabDoc } from '../hooks/useCollabDoc';
 
 interface Props {
   room: string;
-  onPdf: (url: string) => void;
+  onPdf: (blobUrl: string) => void;
   onToast: (msg: string) => void;
   onLog: (log: string | null) => void;
   onStatus: (st: CompileStatus | 'idle') => void;
@@ -31,8 +31,8 @@ const CompileButton: React.FC<Props> = ({ room, onPdf, onToast, onLog, onStatus 
       onLog(result.log || null);
       if (result.status === 'done') {
         const blob = await fetchPdf(jobId);
-        const url = URL.createObjectURL(blob);
-        onPdf(url);
+        const blobUrl = URL.createObjectURL(blob);
+        onPdf(blobUrl);
       } else {
         onToast(result.status);
       }

--- a/apps/frontend/src/components/EditorPage.tsx
+++ b/apps/frontend/src/components/EditorPage.tsx
@@ -10,7 +10,7 @@ import type { CompileStatus } from '../api/compile';
 const ROOM = 'main';
 
 const EditorPage: React.FC = () => {
-  const [pdfUrl, setPdfUrl] = useState<string | null>(null);
+  const [pdfBlobUrl, setPdfBlobUrl] = useState<string | null>(null);
   const [toast, setToast] = useState<string | null>(null);
   const [log, setLog] = useState<string | null>(null);
   const [status, setStatus] = useState<'idle' | CompileStatus>('idle');
@@ -23,11 +23,11 @@ const EditorPage: React.FC = () => {
         <Editor room={ROOM} />
       </div>
       <div className="w-1/2 h-full">
-        <PdfViewer pdfUrl={pdfUrl} />
+        <PdfViewer blobUrl={pdfBlobUrl} />
       </div>
       <CompileButton
         room={ROOM}
-        onPdf={setPdfUrl}
+        onPdf={setPdfBlobUrl}
         onToast={setToast}
         onLog={(l) => setLog(l)}
         onStatus={(s) => {

--- a/apps/frontend/src/components/PdfViewer.tsx
+++ b/apps/frontend/src/components/PdfViewer.tsx
@@ -1,12 +1,18 @@
 import React from 'react';
+import { Document, Page, pdfjs } from 'react-pdf';
+
+pdfjs.GlobalWorkerOptions.workerSrc =
+  `https://cdnjs.cloudflare.com/ajax/libs/pdf.js/${pdfjs.version}/pdf.worker.min.js`;
 
 interface Props {
-  pdfUrl: string | null;
+  blobUrl: string | null;
 }
 
-const PdfViewer: React.FC<Props> = ({ pdfUrl }) => {
-  return pdfUrl ? (
-    <iframe title="pdf-viewer" src={pdfUrl} className="w-full h-full" />
+const PdfViewer: React.FC<Props> = ({ blobUrl }) => {
+  return blobUrl ? (
+    <Document file={blobUrl} className="w-full h-full">
+      <Page pageNumber={1} />
+    </Document>
   ) : null;
 };
 

--- a/apps/frontend/tests/compileFlow.test.tsx
+++ b/apps/frontend/tests/compileFlow.test.tsx
@@ -3,6 +3,11 @@ import '@testing-library/jest-dom/vitest';
 import { vi, describe, it, expect, beforeEach, afterEach } from 'vitest';
 import App from '../src/App';
 import BuildLog from '../src/components/BuildLog';
+vi.mock('react-pdf', () => ({
+  Document: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  Page: () => <canvas data-testid="pdf-canvas" />,
+  pdfjs: { GlobalWorkerOptions: { workerSrc: '' } }
+}));
 import * as Y from 'yjs';
 import { Awareness } from 'y-protocols/awareness';
 const aw = new Awareness(new Y.Doc());
@@ -38,6 +43,7 @@ describe('compile flow', () => {
     fireEvent.click(btn);
     await vi.runAllTimersAsync();
     await waitFor(() => expect(mockedPost).toHaveBeenCalled());
+    await waitFor(() => expect(screen.getByTestId('pdf-canvas')).toBeInTheDocument());
   }, 10000);
 
   it('shows log panel', () => {

--- a/backend/compile-service/tests/test_cors.py
+++ b/backend/compile-service/tests/test_cors.py
@@ -1,0 +1,38 @@
+import importlib
+from fastapi.testclient import TestClient
+import compile_service.app.state as state
+import pytest
+
+
+@pytest.fixture
+def cors_app(monkeypatch):
+    monkeypatch.setenv('COLLATEX_STATE', 'memory')
+    monkeypatch.setenv('COLLATEX_ALLOWED_ORIGINS', 'http://allowed')
+    importlib.reload(state)
+    import compile_service.app.main as main
+    importlib.reload(main)
+    return main.app
+
+
+def test_preflight_allowed(cors_app):
+    with TestClient(cors_app) as client:
+        r = client.options(
+            '/compile',
+            headers={
+                'Origin': 'http://allowed',
+                'Access-Control-Request-Method': 'POST',
+            },
+        )
+        assert r.status_code in {200, 204}
+
+
+def test_preflight_forbidden(cors_app):
+    with TestClient(cors_app) as client:
+        r = client.options(
+            '/compile',
+            headers={
+                'Origin': 'http://evil',
+                'Access-Control-Request-Method': 'POST',
+            },
+        )
+        assert r.status_code == 403

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,6 +8,7 @@ services:
       COLLATEX_STATE: redis
       REDIS_URL: redis://redis:6379
       COLLATEX_API_TOKEN: changeme
+      COLLATEX_ALLOWED_ORIGINS: http://localhost:5173
     ports: ["8080:8080"]
   worker:
     build: ./backend/compile-service
@@ -16,6 +17,7 @@ services:
       COLLATEX_STATE: redis
       REDIS_URL: redis://redis:6379
       COLLATEX_API_TOKEN: changeme
+      COLLATEX_ALLOWED_ORIGINS: http://localhost:5173
   gateway:
     build: ./apps/collab_gateway
     environment:

--- a/scripts/smoke.sh
+++ b/scripts/smoke.sh
@@ -18,6 +18,10 @@ wait_service() {
 wait_service "$backend/healthz"
 wait_service "$gateway/healthz"
 
+curl -fs -X OPTIONS "$backend/compile" \
+  -H 'Origin: http://localhost:5173' \
+  -H 'Access-Control-Request-Method: POST' >/dev/null
+
 tex='\\documentclass{article}\\begin{document}Hi\\end{document}'
 body=$(printf '%s' "$tex" | base64 -w0)
 job=$(curl -fs -X POST "$backend/compile" \


### PR DESCRIPTION
## Summary
- configure allowed CORS origins via `COLLATEX_ALLOWED_ORIGINS`
- add preflight middleware and tests
- swap iframe for react-pdf viewer
- show compiled PDF blob in viewer
- update docker-compose and smoke test for preflight
- document dev frontend usage and CORS env var

## Testing
- `uv run --extra dev ruff check .`
- `uv run --extra dev mypy -p compile_service`
- `uv run --extra dev -m pytest -n auto -q`
- `npm run lint --prefix apps/frontend`
- `npm run test --silent -- --run --prefix apps/frontend`


------
https://chatgpt.com/codex/tasks/task_e_68867f0929f8833192a0732f61c5fbc3