### PR TITLE
Implement Redis rate limiting

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,12 @@ Do **not** open `index.html` directly with `file://`. Always run `npm run dev` o
 use the Dockerised frontend at `http://localhost:5173` so CORS and relative paths
 work correctly.
 
+## Installing dev deps
+
+```bash
+uv pip install -e backend/compile-service[dev]
+```
+
 ## Architecture
 ```mermaid
 graph TD
@@ -76,6 +82,11 @@ WebSocket URL must include `token=<token>`.
 `COLLATEX_ALLOWED_ORIGINS` controls which frontend URLs may access the backend.
 The default is `http://localhost:5173`. Set it to a comma-separated list of
 origins when deploying.
+
+## Rate limits
+
+Each API token may send up to 20 compile requests per hour by default.
+Set `COLLATEX_RATE_LIMIT=20` to adjust the limit.
 
 ## Troubleshooting
 

--- a/backend/compile-service/src/compile_service/app/rate_limit.py
+++ b/backend/compile-service/src/compile_service/app/rate_limit.py
@@ -1,0 +1,35 @@
+from __future__ import annotations
+
+import os
+from datetime import datetime, timedelta
+
+from fastapi import HTTPException, Request
+import redis.asyncio as redis
+
+from ..executor import COMPILE_COUNTER
+
+_DEFAULT_LIMIT = int(os.getenv('COLLATEX_RATE_LIMIT', '20'))
+
+
+async def rate_limit(request: Request) -> None:
+    token = getattr(request.state, 'token', None)
+    if not token:
+        return
+    client: redis.Redis | None = getattr(request.app.state, 'redis', None)
+    if client is None:
+        return
+    now = datetime.utcnow()
+    minute = now.strftime('%Y%m%d%H%M')
+    key = f'rl:{token}:{minute}'
+    pipe = client.pipeline()
+    pipe.incr(key)
+    pipe.expire(key, 3600)
+    await pipe.execute()
+
+    keys = [f'rl:{token}:{(now - timedelta(minutes=i)).strftime("%Y%m%d%H%M")}' for i in range(60)]
+    counts = await client.mget(keys)
+    total = sum(int(c) for c in counts if c)
+    limit = int(os.getenv('COLLATEX_RATE_LIMIT', str(_DEFAULT_LIMIT)))
+    if total > limit:
+        COMPILE_COUNTER.labels(status='rate_limited').inc()
+        raise HTTPException(status_code=429, detail='rate limit exceeded')

--- a/backend/compile-service/src/compile_service/auth.py
+++ b/backend/compile-service/src/compile_service/auth.py
@@ -5,15 +5,14 @@ import os
 from fastapi import HTTPException, Request
 
 
-async def verify_token(request: Request) -> None:
+async def verify_token(request: Request) -> str | None:
     expected = os.getenv('COLLATEX_API_TOKEN')
-    if not expected:
-        return
     header = request.headers.get('Authorization')
     token = None
     if header and header.startswith('Bearer '):
         token = header.split(' ', 1)[1]
     if token is None:
         token = request.query_params.get('token')
-    if token != expected:
+    if expected and token != expected:
         raise HTTPException(status_code=401, detail='unauthorized')
+    return token

--- a/backend/compile-service/tests/test_rate_limit.py
+++ b/backend/compile-service/tests/test_rate_limit.py
@@ -1,0 +1,44 @@
+import asyncio
+import importlib
+
+import fakeredis.aioredis
+import pytest
+from fastapi.testclient import TestClient
+
+from .test_validation import minimal_payload
+
+
+@pytest.fixture
+def limiter_app(monkeypatch):
+    monkeypatch.setenv('COLLATEX_STATE', 'redis')
+    monkeypatch.setenv('COLLATEX_RATE_LIMIT', '20')
+    fake = fakeredis.aioredis.FakeRedis()
+    monkeypatch.setattr('redis.asyncio.Redis.from_url', lambda url='redis://localhost:6379/0': fake)
+    import compile_service.app.state as state
+    import compile_service.app.main as main
+
+    importlib.reload(state)
+    importlib.reload(main)
+    state.init(fake)
+    yield main.app
+    asyncio.run(fake.aclose())
+    stop = getattr(main.app.state, 'worker_stop', None)
+    if stop is not None:
+        stop()
+
+
+def test_rate_limit(limiter_app):
+    payload = minimal_payload()
+    with TestClient(limiter_app) as client:
+        headers1 = {'Authorization': 'Bearer t1'}
+        for _ in range(20):
+            resp = client.post('/compile', json=payload, headers=headers1)
+            assert resp.status_code == 202
+        headers2 = {'Authorization': 'Bearer t2'}
+        resp = client.post('/compile', json=payload, headers=headers2)
+        assert resp.status_code == 202
+        resp = client.post('/compile', json=payload, headers=headers1)
+        assert resp.status_code == 429
+        assert resp.json()['detail'] == 'rate limit exceeded'
+        metrics = client.get('/metrics').text
+        assert 'collatex_compile_total{status="rate_limited"} 1' in metrics

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,6 +9,7 @@ services:
       REDIS_URL: redis://redis:6379
       COLLATEX_API_TOKEN: changeme
       COLLATEX_ALLOWED_ORIGINS: http://localhost:5173
+      COLLATEX_RATE_LIMIT: 20
     ports: ["8080:8080"]
   worker:
     build: ./backend/compile-service
@@ -18,6 +19,7 @@ services:
       REDIS_URL: redis://redis:6379
       COLLATEX_API_TOKEN: changeme
       COLLATEX_ALLOWED_ORIGINS: http://localhost:5173
+      COLLATEX_RATE_LIMIT: 20
   gateway:
     build: ./apps/collab_gateway
     environment:


### PR DESCRIPTION
## Summary
- add a Redis-backed rate limiter dependency
- store auth token on request state
- track rate limited requests in metrics
- document dev dependencies and rate limit env var
- expose COLLATEX_RATE_LIMIT in docker compose
- test rate limiting with fakeredis

## Testing
- `uv run --extra dev ruff check src tests`
- `uv run --extra dev mypy -p compile_service`
- `uv run --extra dev -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6886851c2af48331a32b7456b488e3f4