### PR TITLE
feat: SSE job status + Prometheus metrics

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,3 +104,12 @@ Set `COLLATEX_RATE_LIMIT=20` to adjust the limit.
 
 If a compile fails, open the **Build Log** panel under the PDF viewer. It
 captures the last part of the Tectonic output so you can spot LaTeX errors.
+
+## Realtime status
+
+Clients may follow compile progress via Server-Sent Events. After posting to
+`/compile` the response header `Location` includes the job id. Open an
+`EventSource` on `/stream/jobs/{id}` and listen for JSON messages of the form
+`{"id":"<id>","status":"RUNNING|SUCCEEDED|FAILED"}`. A heartbeat comment is sent
+every 100&nbsp;ms to keep proxies happy. Prometheus metrics are exposed at
+`/metrics` for monitoring compile counts and durations.

--- a/apps/frontend/src/api/compile.ts
+++ b/apps/frontend/src/api/compile.ts
@@ -1,6 +1,6 @@
 import api from './client';
 
-export type CompileStatus = 'queued' | 'running' | 'done' | 'error' | 'limit';
+export type CompileStatus = 'PENDING' | 'RUNNING' | 'SUCCEEDED' | 'FAILED';
 
 export async function startCompile(tex: string): Promise<string> {
   const res = await api.post('/compile', {
@@ -10,11 +10,6 @@ export async function startCompile(tex: string): Promise<string> {
     files: [{ path: 'main.tex', contentBase64: btoa(tex) }]
   });
   return res.data.jobId as string;
-}
-
-export async function pollJob(jobId: string): Promise<{ status: CompileStatus; log?: string }> {
-  const res = await api.get(`/jobs/${jobId}`);
-  return res.data as { status: CompileStatus; log?: string };
 }
 
 export async function fetchPdf(jobId: string): Promise<Blob> {

--- a/apps/frontend/src/components/BuildLog.tsx
+++ b/apps/frontend/src/components/BuildLog.tsx
@@ -16,7 +16,7 @@ const BuildLog: React.FC<Props> = ({ log, status, open, onToggle }) => {
       </button>
       {open && (
         <div className="p-2 font-mono text-sm overflow-y-auto max-h-64">
-          {status === 'running' || status === 'queued' ? (
+          {status === 'RUNNING' || status === 'PENDING' ? (
             <span>Compiling...</span>
           ) : (
             <pre>{log}</pre>

--- a/apps/frontend/src/components/EditorPage.tsx
+++ b/apps/frontend/src/components/EditorPage.tsx
@@ -32,13 +32,13 @@ const EditorPage: React.FC = () => {
         onLog={(l) => setLog(l)}
         onStatus={(s) => {
           setStatus(s);
-          if (s === 'queued' || s === 'running') {
+          if (s === 'PENDING' || s === 'RUNNING') {
             setLogOpen(true);
           }
-          if (s === 'done') {
+          if (s === 'SUCCEEDED') {
             setLogOpen(false);
           }
-          if (s === 'error') {
+          if (s === 'FAILED') {
             setLogOpen(true);
           }
         }}

--- a/backend/compile-service/src/collatex/metrics.py
+++ b/backend/compile-service/src/collatex/metrics.py
@@ -1,0 +1,14 @@
+from __future__ import annotations
+
+from prometheus_client import Counter, Histogram
+
+COMPILE_COUNTER = Counter(
+    'compile_total',
+    'Total compile jobs',
+    labelnames=['status'],
+)
+
+COMPILE_DURATION = Histogram(
+    'compile_duration_seconds',
+    'Duration of compile tasks in seconds',
+)

--- a/backend/compile-service/tests/test_celery.py
+++ b/backend/compile-service/tests/test_celery.py
@@ -1,5 +1,8 @@
 import asyncio
 from pathlib import Path
+import sys
+from pathlib import Path as _P
+sys.path.insert(0, str(_P(__file__).resolve().parents[1] / 'src'))
 
 import fakeredis
 import pytest

--- a/backend/compile-service/tests/test_sse.py
+++ b/backend/compile-service/tests/test_sse.py
@@ -1,0 +1,60 @@
+import asyncio
+import json
+from pathlib import Path
+import sys
+from pathlib import Path as _P
+sys.path.insert(0, str(_P(__file__).resolve().parents[1] / 'src'))
+
+import fakeredis
+import pytest
+from httpx import AsyncClient, ASGITransport
+
+from compile_service.app.main import app
+from collatex.redis_store import init as store_init, get_job, save_job, publish_status
+from collatex.tasks import compile_task
+from collatex.models import JobStatus
+
+@pytest.fixture(autouse=True)
+def setup(monkeypatch):
+    sync_client = fakeredis.FakeRedis()
+    async_client = fakeredis.aioredis.FakeRedis()
+    monkeypatch.setattr('redis.from_url', lambda url, *a, **k: sync_client)
+    monkeypatch.setattr('redis.asyncio.from_url', lambda url, *a, **k: async_client)
+    store_init(sync_client)
+    app.state.redis = sync_client
+    app.state.redis_async = async_client
+    yield
+    asyncio.run(async_client.aclose())
+
+
+@pytest.mark.asyncio
+async def test_sse_success(monkeypatch):
+    def instant(job_id: str, tex: str) -> None:
+        job = get_job(job_id)
+        assert job
+        job.status = JobStatus.RUNNING
+        save_job(job)
+        publish_status(job)
+        job.status = JobStatus.SUCCEEDED
+        pdf = Path('storage') / f'{job_id}.pdf'
+        pdf.parent.mkdir(exist_ok=True)
+        pdf.write_bytes(b'%PDF-1.4')
+        job.pdf_path = str(pdf)
+        save_job(job)
+        publish_status(job)
+
+    monkeypatch.setattr(compile_task, 'delay', instant)
+    async with AsyncClient(transport=ASGITransport(app=app), base_url='http://test') as client:
+        r = await client.post('/compile', json={'tex': 'hi'})
+        job_id = r.headers['Location'].split('/')[-1]
+        statuses = []
+        async with client.stream('GET', f'/stream/jobs/{job_id}') as stream:
+            async for line in stream.aiter_lines():
+                if line.startswith('data:'):
+                    payload = json.loads(line[5:])
+                    statuses.append(payload['status'])
+                    if payload['status'] == 'SUCCEEDED':
+                        break
+        assert statuses == ['RUNNING', 'SUCCEEDED']
+        metrics = (await client.get('/metrics')).text
+        assert 'compile_total{status="succeeded"} 1.0' in metrics


### PR DESCRIPTION
## Summary
- publish job status to Redis
- expose status stream endpoint and metrics
- instrument Celery task with Prometheus counters
- update README with realtime status docs
- watch compile progress in the frontend via EventSource
- add async SSE test

## Testing
- `uv run --extra dev ruff check .`
- `uv run --extra dev mypy -p compile_service`
- `uv run --extra dev -m pytest -n 1 -q`

------
https://chatgpt.com/codex/tasks/task_e_68872ca6357883318d24f7ebda4f9f86