### PR TITLE
chore: one-shot docker-compose (worker included) + robust env defaults

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -3,6 +3,9 @@ ARTIFACTS_DIR=var/artifacts
 COMPILE_TIMEOUT_SECONDS=30
 MAX_UPLOAD_BYTES=2097152
 
+# Runtime defaults
+REDIS_URL=redis://redis:6379/0
+
 # Frontend
-COMPILE_API_URL=http://localhost:8080
+VITE_API_ORIGIN=http://localhost:8080
 COLLAB_WS_URL=ws://localhost:1234

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -18,15 +18,20 @@ jobs:
         run: pip install uv
       - name: Install deps
         run: uv pip install -e backend/compile-service[dev]
-      - name: Start Redis (if needed)
-        if: matrix.state == 'redis'
-        run: docker run -d -p 6379:6379 redis:7-alpine
+      - name: Start stack
+        run: docker compose up -d --build
+      - name: Wait for API
+        run: |
+          for i in {1..30}; do
+            curl -fs http://localhost:8080/healthz && break
+            sleep 2
+          done
       - name: Lint
         run: make lint
       - name: Type-check
         run: make typecheck
       - name: Tests
-        run: make test
+        run: uv run -m pytest -n auto -q
   gateway:
     runs-on: ubuntu-latest
     strategy:

--- a/README.md
+++ b/README.md
@@ -49,11 +49,8 @@ Tasks:
 ## Dev loop
 ```bash
 # Quick start
-uv pip install -e backend/compile-service[worker]
-celery -A collatex.tasks worker -Q compile -l info &
-docker compose up --build  # optional, native setup works too
-./scripts/smoke.sh
-open http://localhost:5173
+cp .env.example .env
+docker compose up --build
 ```
 Do **not** open `index.html` directly with `file://`. Always run `npm run dev` or
 use the Dockerised frontend at `http://localhost:5173` so CORS and relative paths

--- a/apps/frontend/src/config.ts
+++ b/apps/frontend/src/config.ts
@@ -2,4 +2,4 @@ const env = typeof import.meta !== 'undefined' ? import.meta.env : {};
 export const WS_URL =
   (process.env.VITE_WS_URL as string) || env.VITE_WS_URL || 'ws://localhost:1234';
 export const API_URL =
-  (process.env.VITE_API_URL as string) || env.VITE_API_URL || 'http://localhost:8080';
+  (process.env.VITE_API_ORIGIN as string) || env.VITE_API_ORIGIN || 'http://localhost:8080';

--- a/apps/frontend/vite.config.ts
+++ b/apps/frontend/vite.config.ts
@@ -1,6 +1,11 @@
 import { defineConfig } from 'vite';
 import react from '@vitejs/plugin-react';
 
+const apiOrigin = process.env.VITE_API_ORIGIN || 'http://localhost:8080';
+
 export default defineConfig({
   plugins: [react()],
+  define: {
+    'process.env.VITE_API_ORIGIN': JSON.stringify(apiOrigin),
+  },
 });

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,22 +4,24 @@ services:
     image: redis:7-alpine
   backend:
     build: ./backend/compile-service
+    volumes:
+      - ./storage:/app/storage
     environment:
       COLLATEX_STATE: redis
-      REDIS_URL: redis://redis:6379
+      REDIS_URL: redis://redis:6379/0
       COLLATEX_API_TOKEN: changeme
       COLLATEX_ALLOWED_ORIGINS: http://localhost:5173
       COLLATEX_RATE_LIMIT: 20
     ports: ["8080:8080"]
   worker:
     build: ./backend/compile-service
-    entrypoint: ["uv", "run", "compile_service.worker:main"]
+    command: celery -A collatex.tasks worker -Q compile -l info
+    volumes:
+      - ./storage:/app/storage
     environment:
-      COLLATEX_STATE: redis
-      REDIS_URL: redis://redis:6379
-      COLLATEX_API_TOKEN: changeme
-      COLLATEX_ALLOWED_ORIGINS: http://localhost:5173
-      COLLATEX_RATE_LIMIT: 20
+      - REDIS_URL=redis://redis:6379/0
+    depends_on:
+      - redis
   gateway:
     build: ./apps/collab_gateway
     environment:


### PR DESCRIPTION
## Summary
- make worker use celery & share storage
- mount storage on backend
- add `.env.example` defaults and update quick-start
- expose `VITE_API_ORIGIN` in vite config
- run stack in CI before pytest

## Testing
- `ruff check .`
- `mypy -p compile_service`
- `pytest -n auto -q`

------
https://chatgpt.com/codex/tasks/task_e_68874b4e29cc83318e5f50ef05d849ab