### PR TITLE
Fix build and local dev setup

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,10 +17,10 @@ dev-backend:
 
 # Collab websocket (pin y-websocket and auto-confirm with -y)
 dev-collab: check-node
-        npm --prefix apps/collab_gateway run dev
+	npm --prefix apps/collab_gateway run dev
 
 dev-frontend: check-node
-        npm --prefix apps/frontend run dev
+	npm --prefix apps/frontend run dev
 
 dev-redis:
 	docker run --rm -p 6379:6379 redis:7-alpine
@@ -33,7 +33,7 @@ test:
 	if [ "$$COLLATEX_STATE" = "redis" ]; then \
 	python scripts/check_redis.py; \
 	fi
-	cd backend/compile-service && uv run --extra dev -m pytest -n auto -q
+	cd backend/compile-service && PYTHONPATH="$$(pwd)/src" uv run --extra dev -m pytest -n auto -q
 
 lint:
 	cd backend/compile-service && uv run --extra dev ruff check .

--- a/apps/collab_gateway/src/index.ts
+++ b/apps/collab_gateway/src/index.ts
@@ -1,7 +1,9 @@
 import http from 'http';
 import express from 'express';
 import { Server as WebSocketServer } from 'ws';
-import { setupWSConnection } from 'y-websocket/bin/utils';
+// The utils module ships only JavaScript, so we import the file directly
+// and rely on our local declaration for types.
+import { setupWSConnection } from 'y-websocket/bin/utils.js';
 import { connectionsTotal, register } from './metrics';
 import { createClient } from 'redis';
 

--- a/apps/collab_gateway/tsconfig.json
+++ b/apps/collab_gateway/tsconfig.json
@@ -6,11 +6,15 @@
     "esModuleInterop": true,
     "forceConsistentCasingInFileNames": true,
     "skipLibCheck": true,
-    "outDir": "dist"
+    "outDir": "dist",
+    "typeRoots": ["./src/types", "./node_modules/@types"]
   },
   "include": [
     "src/**/*.ts",
     "tests/**/*.ts",
     "src/types/**/*.d.ts"
+  ],
+  "files": [
+    "src/types/y-websocket.d.ts"
   ]
 }

--- a/apps/frontend/Dockerfile
+++ b/apps/frontend/Dockerfile
@@ -2,7 +2,7 @@ FROM node:20-alpine AS build
 ARG VITE_API_TOKEN=changeme
 WORKDIR /app
 COPY . .
-RUN npm ci --omit=dev && VITE_API_TOKEN=$VITE_API_TOKEN npm run build
+RUN npm ci && VITE_API_TOKEN=$VITE_API_TOKEN npm run build
 FROM nginx:1.27-alpine
 COPY --from=build /app/dist /usr/share/nginx/html
 EXPOSE 80

--- a/scripts/dev_local.sh
+++ b/scripts/dev_local.sh
@@ -15,9 +15,15 @@ cleanup() {
 }
 trap cleanup EXIT INT TERM
 
-COLLATEX_STATE=fakeredis uv run compile_service.app.main:app &
+(
+  cd backend/compile-service && \
+  PYTHONPATH="$(pwd)/src" COLLATEX_STATE=fakeredis uv run uvicorn compile_service.app.main:app --reload --port 8080
+) &
 APP_PID=$!
-COLLATEX_STATE=fakeredis uv run compile_service.worker:main &
+(
+  cd backend/compile-service && \
+  PYTHONPATH="$(pwd)/src" COLLATEX_STATE=fakeredis uv run -m compile_service.worker
+) &
 WORKER_PID=$!
 npm --prefix apps/collab_gateway run dev &
 GATEWAY_PID=$!


### PR DESCRIPTION
## Summary
- install dev deps when building frontend so vite is available
- run backend and worker with PYTHONPATH set to compile-service source
- resolve collab_gateway TS types for y-websocket
- ensure Makefile test target adds PYTHONPATH

## Testing
- `PYTHONPATH="$(pwd)/src" uv run --extra dev -m pytest tests/test_health.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68879102896083318ca272978cf31571