### PR TITLE
Fix dev script errors

### DIFF
--- a/apps/collab_gateway/src/index.ts
+++ b/apps/collab_gateway/src/index.ts
@@ -3,7 +3,9 @@ import express from 'express';
 import { Server as WebSocketServer } from 'ws';
 // The utils module ships only JavaScript, so we import the file directly
 // and rely on our local declaration for types.
-import { setupWSConnection } from 'y-websocket/bin/utils.js';
+// y-websocket exposes the utils subpath explicitly. Importing without the file
+// extension ensures Node can resolve it via the package export map.
+import { setupWSConnection } from 'y-websocket/bin/utils';
 import { connectionsTotal, register } from './metrics';
 import { createClient } from 'redis';
 

--- a/apps/frontend/src/App.tsx
+++ b/apps/frontend/src/App.tsx
@@ -12,7 +12,7 @@ const App: React.FC = () => {
   const match = window.location.pathname.match(/^\/p\/(\w+)/);
   if (!match) {
     return (
-      <button className="m-4 p-2 bg-blue-500 text-white" onClick={newProject}">
+      <button className="m-4 p-2 bg-blue-500 text-white" onClick={newProject}>
         New Project
       </button>
     );

--- a/apps/frontend/src/components/Editor.tsx
+++ b/apps/frontend/src/components/Editor.tsx
@@ -11,7 +11,7 @@ interface Props {
   token: string;
 }
 
-const Editor: React.FC<Props> = ({ room }) => {
+const Editor: React.FC<Props> = ({ room, token }) => {
   const { ytext, awareness } = useCollabDoc(room, token);
   const divRef = useRef<HTMLDivElement>(null);
   const viewRef = useRef<EditorView>();

--- a/apps/frontend/src/config.ts
+++ b/apps/frontend/src/config.ts
@@ -1,5 +1,7 @@
-const env = typeof import.meta !== 'undefined' ? import.meta.env : {};
-export const WS_URL =
-  (process.env.VITE_WS_URL as string) || env.VITE_WS_URL || 'ws://localhost:1234';
-export const API_URL =
-  (process.env.VITE_API_ORIGIN as string) || env.VITE_API_ORIGIN || 'http://localhost:8080';
+// Vite injects environment variables via `import.meta.env` during build time.
+// In the browser we don't have access to `process.env`, so rely solely on
+// `import.meta.env` with sensible defaults for development.
+const env = (typeof import.meta !== 'undefined' ? (import.meta as any).env : {}) as Record<string, string>;
+
+export const WS_URL = env.VITE_WS_URL ?? 'ws://localhost:1234';
+export const API_URL = env.VITE_API_ORIGIN ?? 'http://localhost:8080';


### PR DESCRIPTION
## Summary
- adjust y-websocket import and types to match export map
- fix JSX typo in `App.tsx`
- pass token prop in `Editor`
- rely on `import.meta.env` for frontend config

## Testing
- `make lint`
- `make typecheck`
- `make test` *(1 passed, 20 skipped)*

------
https://chatgpt.com/codex/tasks/task_e_6887a00f6b4083318b029ee1c5944635