### PR TITLE
fix dev script extras

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,6 +4,6 @@ RUN curl -L https://github.com/tectonic-typesetting/tectonic/releases/download/t
 WORKDIR /app
 COPY backend/compile-service backend/compile-service
 RUN pip install uv
-RUN uv pip install --system backend/compile-service[dev]
+RUN uv pip install --system ./backend/compile-service[dev]
 WORKDIR /app/backend/compile-service
 CMD ["uvicorn", "compile_service.app.main:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ work correctly.
 ## Installing dev deps
 
 ```bash
-uv pip install -e backend/compile-service[dev]
+uv pip install -e ./backend/compile-service[dev]
 ```
 
 ## Running without Docker

--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -1,5 +1,5 @@
 services:
-  backend:
+  compile-service:
     environment:
       COLLATEX_SECRET: supersecret
       COLLATEX_DEMO_EMAIL: demo@example.com

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,16 +2,13 @@ version: "3.9"
 services:
   redis:
     image: redis:7-alpine
-  backend:
-    build:
-      context: ./backend/compile-service
-      network: host
   compile-service:
     build:
       context: .
+      dockerfile: Dockerfile
       network: host
     ports:
-      - "8000:8000"
+      - "8080:8000"
     volumes:
       - ./storage:/app/storage
     environment:
@@ -20,9 +17,10 @@ services:
       COLLATEX_API_TOKEN: changeme
       COLLATEX_ALLOWED_ORIGINS: http://localhost:5173
       COLLATEX_RATE_LIMIT: 20
-    ports: ["8080:8080"]
   worker:
-    build: ./backend/compile-service
+    build:
+      context: .
+      dockerfile: Dockerfile
     command: celery -A collatex.tasks worker -Q compile -l info
     volumes:
       - ./storage:/app/storage

--- a/scripts/dev_local.sh
+++ b/scripts/dev_local.sh
@@ -5,7 +5,7 @@ if command -v docker >/dev/null 2>&1; then
   echo "Docker detected. If you want the containerised stack, run: docker compose up" >&2
 fi
 
-uv pip install -e backend/compile-service[dev]
+uv pip install -e ./backend/compile-service[dev]
 
 npm --prefix apps/collab_gateway install
 npm --prefix apps/frontend install


### PR DESCRIPTION
## Summary
- fix path to install optional deps
- align compose and Dockerfile with this change

## Testing
- `make lint`
- `make typecheck`
- `make test` *(fails: KeyboardInterrupt)*

------
https://chatgpt.com/codex/tasks/task_e_6887b3c3db508331a1dad1a34304f445