### PR TITLE
Fix docker frontend build

### DIFF
--- a/apps/frontend/Dockerfile
+++ b/apps/frontend/Dockerfile
@@ -2,7 +2,7 @@ FROM node:20-alpine AS build
 ARG VITE_API_TOKEN=changeme
 WORKDIR /app
 COPY . .
-RUN npm ci && VITE_API_TOKEN=$VITE_API_TOKEN npm run build
+RUN npm ci && VITE_API_TOKEN=$VITE_API_TOKEN npx vite build
 FROM nginx:1.27-alpine
 COPY --from=build /app/dist /usr/share/nginx/html
 EXPOSE 80


### PR DESCRIPTION
## Summary
- use `npx vite build` in the frontend Dockerfile to ensure local vite binary is used

## Testing
- `make lint`
- `make typecheck`
- `make test` *(fails: KeyboardInterrupt after tests run)*

------
https://chatgpt.com/codex/tasks/task_e_6887b8ffe16c833181a284056f3e9f31