### PR TITLE
Fix Docker build for gateway

### DIFF
--- a/apps/collab_gateway/Dockerfile
+++ b/apps/collab_gateway/Dockerfile
@@ -1,6 +1,7 @@
 FROM node:20-alpine
 WORKDIR /app
 COPY . .
-RUN npm ci --omit=dev && npm run build
+# Install all deps including dev tools (for tsc), then prune
+RUN npm ci && npm run build && npm prune --omit=dev
 CMD ["node", "dist/index.js"]
 


### PR DESCRIPTION
## Summary
- ensure TypeScript compiler is installed for the collab gateway Docker image

## Testing
- `make lint`
- `make typecheck`
- `make test` *(fails: KeyboardInterrupt but output shows tests passed)*

------
https://chatgpt.com/codex/tasks/task_e_6887c0706f80833183d841e23dc4a505