### PR TITLE
Auto-start Redis for local development

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,10 @@ uv pip install -e ./backend/compile-service[dev]
 ./scripts/dev_local.sh
 ```
 
+`dev_local.sh` automatically starts Redis on port 6379 if it's not running. If
+the `redis-server` binary is missing, it falls back to an in-process redislite
+instance.
+
 ## Native run
 
 ```bash
@@ -79,9 +83,9 @@ celery -A collatex.tasks worker -Q compile -l info
 # then npm run dev in frontend
 ```
 
-This installs Python and Node deps locally and starts the services with
-`COLLATEX_STATE=fakeredis`. Compilation produces a stub PDF unless Tectonic is
-installed.
+This installs Python and Node deps locally and starts the services. Redis will
+be started automatically unless you already have one running. Compilation
+produces a stub PDF unless Tectonic is installed.
 
 ## Architecture
 ```mermaid

--- a/backend/compile-service/src/collatex/redis_store.py
+++ b/backend/compile-service/src/collatex/redis_store.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from datetime import datetime
 from typing import Optional, cast, Dict
 import json
+import os
 
 import redis
 
@@ -16,7 +17,12 @@ PROJECT_KEY = 'collatex:projects'
 
 def init(client: redis.Redis) -> None:
     global _REDIS
-    _REDIS = client
+    if os.getenv('COLLATEX_USE_REDISLITE'):
+        import redislite  # type: ignore
+
+        _REDIS = redislite.StrictRedis()
+    else:
+        _REDIS = client
 
 
 def create_project(project: Project) -> None:


### PR DESCRIPTION
## Summary
- start a local Redis instance in `dev_local.sh`
- fall back to in-process redislite when redis-server is missing
- expose the redislite option in `collatex.redis_store`
- document the new dev script behavior

## Testing
- `make fmt`
- `make lint`
- `make typecheck`
- `make test` *(passes with 1 test and 20 skipped)*

------
https://chatgpt.com/codex/tasks/task_e_6888e5957b3083318d216f33ccbd7501