### PR TITLE
Fix dash tokens in gateway

### DIFF
--- a/apps/collab_gateway/src/index.ts
+++ b/apps/collab_gateway/src/index.ts
@@ -59,7 +59,7 @@ export function createServer(): http.Server {
   const wss = new WebSocketServer({ noServer: true });
   server.on('upgrade', async (req, socket, head) => {
     const url = new URL(req.url || '/', 'http://localhost');
-    const match = url.pathname.match(/^\/yjs\/(\w+)/);
+    const match = url.pathname.match(/^\/yjs\/([\w-]+)/);
     const token = match ? match[1] : null;
     if (!token) {
       socket.destroy();

--- a/backend/compile-service/src/compile_service/app/main.py
+++ b/backend/compile-service/src/compile_service/app/main.py
@@ -33,13 +33,13 @@ from collatex.settings import TESTING, REDIS_URL
 
 
 def compile_tex_sync(tex_source: str, pdf_path: Path) -> None:
-    pdf_path.write_bytes(b"%PDF-1.4\n% dummy PDF for tests\n")
+    pdf_path.write_bytes(b'%PDF-1.4\n% dummy PDF for tests\n')
 
 FRONTEND_ORIGIN = os.getenv('FRONTEND_ORIGIN', 'http://localhost:5173')
 
 
 @asynccontextmanager
-async def lifespan(app: FastAPI):
+async def lifespan(app: FastAPI) -> AsyncGenerator[None, None]:
     url = REDIS_URL
     client = redis.from_url(url)  # type: ignore[no-untyped-call]
     store_init(client)

--- a/backend/compile-service/tests/conftest.py
+++ b/backend/compile-service/tests/conftest.py
@@ -1,7 +1,7 @@
 import os
 import pytest
 
-os.environ["COLLATEX_TESTING"] = "1"
+os.environ['COLLATEX_TESTING'] = '1'
 from compile_service.app.main import app
 
 @pytest.fixture

--- a/backend/compile-service/tests/helpers.py
+++ b/backend/compile-service/tests/helpers.py
@@ -4,7 +4,6 @@ import os
 import socket
 import urllib.parse
 
-import pytest
 
 
 def require_redis() -> None:

--- a/backend/compile-service/tests/test_project_flow.py
+++ b/backend/compile-service/tests/test_project_flow.py
@@ -4,8 +4,8 @@ from pathlib import Path
 import os
 import pytest
 
-if os.getenv("COLLATEX_TESTING") == "1":
-    pytest.skip("project flow not needed in test mode", allow_module_level=True)
+if os.getenv('COLLATEX_TESTING') == '1':
+    pytest.skip('project flow not needed in test mode', allow_module_level=True)
 
 import fakeredis
 from httpx import AsyncClient, ASGITransport


### PR DESCRIPTION
## Summary
- allow hyphens in yjs websocket tokens
- test websocket token patterns
- fix mypy and ruff warnings

## Testing
- `make lint`
- `make typecheck`
- `make test`
- `npm --prefix apps/collab_gateway test`
- `npm --prefix apps/frontend test`

------
https://chatgpt.com/codex/tasks/task_e_688a32ca81648331898f462bbb6f2aeb