### PR TITLE
Fix missing CodeMirror CSS

### DIFF
--- a/apps/frontend/src/index.css
+++ b/apps/frontend/src/index.css
@@ -1,3 +1,6 @@
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
+
+/* Include CodeMirror base styles so the editor renders correctly */
+@import '@codemirror/view/style.css';


### PR DESCRIPTION
## Summary
- include CodeMirror base stylesheet so the editor is visible

## Testing
- `npm --prefix apps/frontend run lint`
- `npm --prefix apps/frontend run typecheck`
- `npm --prefix apps/frontend run test`
- `make lint`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_688a57ecb92c8331b68323571c424f81