### PR TITLE
Fix CodeMirror visibility

### DIFF
--- a/apps/frontend/src/index.css
+++ b/apps/frontend/src/index.css
@@ -1,4 +1,5 @@
 /* Include CodeMirror base styles so the editor renders correctly */
+@import '@codemirror/view/style.css';
 @tailwind base;
 @tailwind components;
 @tailwind utilities;


### PR DESCRIPTION
## Summary
- include CodeMirror base CSS so editor renders

## Testing
- `npm run lint` in `apps/frontend`
- `npm run typecheck` in `apps/frontend`
- `npx vitest run` in `apps/frontend`

------
https://chatgpt.com/codex/tasks/task_e_688a6c816efc83318dadf8c2e2604ff3