### PR TITLE
Fix missing CodeMirror CSS import

### DIFF
--- a/apps/frontend/src/index.css
+++ b/apps/frontend/src/index.css
@@ -1,5 +1,4 @@
-/* Include CodeMirror base styles so the editor renders correctly */
-@import '@codemirror/view/style.css';
+/* CodeMirror base styles were previously imported here. */
 @tailwind base;
 @tailwind components;
 @tailwind utilities;


### PR DESCRIPTION
## Summary
- remove outdated CodeMirror CSS import

## Testing
- `npm --prefix apps/frontend run lint`
- `npm --prefix apps/frontend run typecheck`
- `npm --prefix apps/frontend run test` (then quit watch mode)


------
https://chatgpt.com/codex/tasks/task_e_688a6f1f1ba08331a7a3e39c91ab0045