### PR TITLE
Fix CodeMirror style import

### DIFF
--- a/apps/frontend/src/index.css
+++ b/apps/frontend/src/index.css
@@ -1,5 +1,4 @@
-/* Include CodeMirror base styles so the editor renders correctly */
-@import '@codemirror/view/style.css';
+/* CodeMirror includes its base theme dynamically, so no CSS import needed */
 @tailwind base;
 @tailwind components;
 @tailwind utilities;


### PR DESCRIPTION
## Summary
- remove stale `@codemirror/view/style.css` import

## Testing
- `npx eslint "src/**/*.{ts,tsx}" --max-warnings=0`
- `npx vitest run`


------
https://chatgpt.com/codex/tasks/task_e_688a6f1f1ba08331a7a3e39c91ab0045