### PR TITLE
Fix full-height editor behavior

### DIFF
--- a/apps/frontend/src/components/CodeMirror.tsx
+++ b/apps/frontend/src/components/CodeMirror.tsx
@@ -13,20 +13,25 @@ interface Props {
   onReady?: (text: Y.Text) => void;
 }
 
+const fillParent = EditorView.theme({
+  '&': { height: '100%' },
+  '.cm-scroller': { overflow: 'auto' },
+});
+
 const CodeMirror: React.FC<Props> = ({ token, gatewayWS, onReady }) => {
   const ref = useRef<HTMLDivElement>(null);
   const viewRef = useRef<EditorView>();
 
   useEffect(() => {
     const ydoc = new Y.Doc();
-    const provider = new WebsocketProvider(gatewayWS, token, ydoc);
-    const ytext = ydoc.getText('main');
+    const provider = new WebsocketProvider(`${gatewayWS}/${token}`, 'document', ydoc);
+    const ytext = ydoc.getText('document');
     if (ytext.length === 0) {
       ytext.insert(0, '\\documentclass{article}\\begin{document}\\end{document}');
     }
     const state = EditorState.create({
       doc: ytext.toString(),
-      extensions: [keymap.of(defaultKeymap), latex(), yCollab(ytext, provider.awareness)],
+      extensions: [fillParent, keymap.of(defaultKeymap), latex(), yCollab(ytext, provider.awareness)],
     });
     viewRef.current = new EditorView({ state, parent: ref.current! });
     onReady?.(ytext);
@@ -36,7 +41,7 @@ const CodeMirror: React.FC<Props> = ({ token, gatewayWS, onReady }) => {
     };
   }, [token, gatewayWS, onReady]);
 
-  return <div ref={ref} className="h-full" />;
+  return <div ref={ref} className="h-full min-h-0" />;
 };
 
 export default CodeMirror;

--- a/apps/frontend/src/components/Editor.tsx
+++ b/apps/frontend/src/components/Editor.tsx
@@ -11,6 +11,11 @@ interface Props {
   token: string;
 }
 
+const fillParent = EditorView.theme({
+  '&': { height: '100%' },
+  '.cm-scroller': { overflow: 'auto' },
+});
+
 const Editor: React.FC<Props> = ({ room, token }) => {
   const { ytext, awareness } = useCollabDoc(room, token);
   const divRef = useRef<HTMLDivElement>(null);
@@ -21,6 +26,7 @@ const Editor: React.FC<Props> = ({ room, token }) => {
       const state = EditorState.create({
         doc: ytext.toString(),
         extensions: [
+          fillParent,
           keymap.of(defaultKeymap),
           latex(),
           yCollab(ytext, awareness)
@@ -33,7 +39,7 @@ const Editor: React.FC<Props> = ({ room, token }) => {
     };
   }, [ytext, awareness]);
 
-  return <div className="h-full" ref={divRef} />;
+  return <div className="h-full min-h-0" ref={divRef} />;
 };
 
 export default Editor;

--- a/apps/frontend/src/components/EditorPage.tsx
+++ b/apps/frontend/src/components/EditorPage.tsx
@@ -18,11 +18,11 @@ const EditorPage: React.FC<Props> = ({ token }) => {
   const [logOpen, setLogOpen] = useState(false);
 
   return (
-    <div className="flex h-full relative">
-      <div className="w-1/2 h-full">
+    <div className="flex min-h-0 h-full relative">
+      <div className="w-1/2 h-full min-h-0">
         <Editor room={ROOM} token={token} />
       </div>
-      <div className="w-1/2 h-full">
+      <div className="w-1/2 h-full min-h-0">
         <PdfViewer blobUrl={pdfBlobUrl} />
       </div>
       <CompileButton

--- a/apps/frontend/src/index.css
+++ b/apps/frontend/src/index.css
@@ -1,4 +1,7 @@
 /* CodeMirror includes its base theme dynamically, so no CSS import needed */
+html, body, #root {
+  height: 100%;
+}
 @tailwind base;
 @tailwind components;
 @tailwind utilities;

--- a/apps/frontend/src/pages/EditorPage.tsx
+++ b/apps/frontend/src/pages/EditorPage.tsx
@@ -36,11 +36,11 @@ const EditorPage: React.FC = () => {
   };
 
   return (
-    <div className="flex h-full">
-      <div className="w-1/2 p-2 h-full">
+    <div className="flex min-h-0 h-full">
+      <div className="w-1/2 p-2 h-full min-h-0">
         <CodeMirror token={token} gatewayWS={gatewayWS} onReady={handleReady} />
       </div>
-      <div className="w-1/2 p-2 flex flex-col h-full">
+      <div className="w-1/2 p-2 flex flex-col h-full min-h-0">
         <button onClick={handleCompile} className="btn bg-blue-500 text-white px-2 py-1 mb-2">Compile</button>
         {status === 'running' && <Spinner />}
         <iframe src={pdfUrl} title="pdf" className="w-full h-[90%] border" />


### PR DESCRIPTION
## Summary
- tweak Editor and CodeMirror components to allow full-height rendering
- update WebsocketProvider URL and Y.Text key
- ensure global CSS gives html/body/root full height
- add min-h-0 classes to flex containers

## Testing
- `npm --prefix apps/frontend run lint`
- `npm --prefix apps/frontend run test` *(cancelled watch mode after pass)*
- `npm --prefix apps/frontend run typecheck`
- `make lint`
- `make typecheck`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_688ba71ac20483318ebfae0aafbc655f