### PR TITLE
fix: send json to compile

### DIFF
--- a/apps/frontend/src/pages/EditorPage.tsx
+++ b/apps/frontend/src/pages/EditorPage.tsx
@@ -20,19 +20,18 @@ const EditorPage: React.FC = () => {
     if (!ytext) return;
     logDebug('compile start');
     setStatus('running');
-    const form = new FormData();
-    form.append('tex', ytext.toString());
     const res = await fetch(`${api}/compile?project=${token}`, {
       method: 'POST',
-      body: form,
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ tex: ytext.toString() }),
     });
-    const { job_id } = await res.json();
-    logDebug('job_id', job_id);
-    const es = new EventSource(`${api}/stream/jobs/${job_id}?project=${token}`);
+    const { jobId } = await res.json();
+    logDebug('job_id', jobId);
+    const es = new EventSource(`${api}/stream/jobs/${jobId}?project=${token}`);
     es.onmessage = (e) => {
       const { status: s } = JSON.parse(e.data) as { status: string };
       if (s === 'SUCCEEDED') {
-        setPdfUrl(`${api}/pdf/${job_id}?project=${token}`);
+        setPdfUrl(`${api}/pdf/${jobId}?project=${token}`);
         setStatus('idle');
         es.close();
         logDebug('compile done');

--- a/apps/frontend/tests/compileFlow.test.tsx
+++ b/apps/frontend/tests/compileFlow.test.tsx
@@ -14,7 +14,7 @@ process.env.VITE_API_TOKEN = 'tkn';
 describe('compile flow', () => {
   beforeEach(() => {
     vi.stubGlobal('URL', { createObjectURL: vi.fn(() => 'blob:url') });
-    vi.stubGlobal('fetch', vi.fn(() => Promise.resolve({ json: () => ({ job_id: 'abc' }) } as any)));
+    vi.stubGlobal('fetch', vi.fn(() => Promise.resolve({ json: () => ({ jobId: 'abc' }) } as any)));
     class ES {
       onmessage: ((ev: MessageEvent) => void) | null = null;
       close = vi.fn();

--- a/backend/compile-service/src/compile_service/app/main.py
+++ b/backend/compile-service/src/compile_service/app/main.py
@@ -97,7 +97,7 @@ async def create_project_endpoint() -> JSONResponse:
 @app.post('/compile', status_code=202)
 async def compile_endpoint(
     req: CompileRequest, project: Project = Depends(require_project)
-) -> Response:
+) -> JSONResponse:
     job_id = str(uuid.uuid4())
     job = Job(id=job_id, project_token=project.token, created_at=datetime.utcnow())
     await run_in_threadpool(save_job, job)
@@ -112,7 +112,11 @@ async def compile_endpoint(
         await run_in_threadpool(publish_status, job)
     else:
         compile_task.delay(job_id, req.tex)
-    return Response(status_code=202, headers={'Location': f'/jobs/{job_id}?project={project.token}'})
+    return JSONResponse(
+        {'jobId': job_id},
+        status_code=202,
+        headers={'Location': f'/jobs/{job_id}?project={project.token}'},
+    )
 
 
 @app.get('/jobs/{job_id}')


### PR DESCRIPTION
## Summary
- send compile requests as JSON and handle jobId in frontend
- return jobId JSON response from compile endpoint
- update compile flow test mocks

## Testing
- `npm --prefix apps/frontend run lint`
- `npm --prefix apps/frontend run typecheck`
- `npm --prefix apps/frontend test -- --run`
- `make lint`
- `make typecheck`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_688df07ac9488331a2b7230f28b5a9ac