### PR TITLE
fix: show compiled PDF when job already finished

### DIFF
--- a/apps/frontend/src/pages/EditorPage.tsx
+++ b/apps/frontend/src/pages/EditorPage.tsx
@@ -27,6 +27,16 @@ const EditorPage: React.FC = () => {
     });
     const { jobId } = await res.json();
     logDebug('job_id', jobId);
+
+    const statusRes = await fetch(`${api}/jobs/${jobId}?project=${token}`);
+    const jobData = (await statusRes.json()) as { status: string };
+    if (jobData.status === 'SUCCEEDED') {
+      setPdfUrl(`${api}/pdf/${jobId}?project=${token}`);
+      setStatus('idle');
+      logDebug('compile done');
+      return;
+    }
+
     const es = new EventSource(`${api}/stream/jobs/${jobId}?project=${token}`);
     es.onmessage = (e) => {
       const { status: s } = JSON.parse(e.data) as { status: string };


### PR DESCRIPTION
## Summary
- ensure frontend displays compiled PDF even if job already succeeded before SSE connects

## Testing
- `npm --prefix apps/frontend run lint`
- `npm --prefix apps/frontend run typecheck`
- `npm --prefix apps/frontend test`
- `make lint`
- `make typecheck`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_688f3a1fdcfc8331a0fb46b136f3fc20