### PR TITLE
feat: add verbose debug logging

### DIFF
--- a/backend/compile-service/src/compile_service/logging.py
+++ b/backend/compile-service/src/compile_service/logging.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import logging
+import os
 from contextvars import ContextVar
 
 import structlog
@@ -12,9 +13,11 @@ job_id_var: ContextVar[str] = ContextVar('job_id', default='')
 
 def configure_logging() -> None:
     """Configure structlog for JSON output."""
-    logging.basicConfig(level=logging.INFO, force=True)
+    level_name = os.getenv('COLLATEX_LOG_LEVEL', 'DEBUG').upper()
+    level = getattr(logging, level_name, logging.DEBUG)
+    logging.basicConfig(level=level, force=True)
     structlog.configure(
-        wrapper_class=structlog.make_filtering_bound_logger(logging.INFO),
+        wrapper_class=structlog.make_filtering_bound_logger(level),
         logger_factory=structlog.stdlib.LoggerFactory(),
         processors=[
             structlog.processors.TimeStamper(fmt='iso', utc=True, key='timestamp'),


### PR DESCRIPTION
## Summary
- improve debug output across frontend compile flow
- enable backend debug logging by default and add detailed task and API logs

## Testing
- `npm --prefix apps/frontend run lint`
- `npm --prefix apps/frontend run typecheck`
- `npm --prefix apps/frontend test -- --run`
- `make lint`
- `make typecheck`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_688f59bba4cc8331b69f1dd811e826da