### PR TITLE
fix: restore PDF viewer

### DIFF
--- a/apps/frontend/src/components/PdfViewer.tsx
+++ b/apps/frontend/src/components/PdfViewer.tsx
@@ -1,0 +1,13 @@
+import React from 'react';
+
+interface Props {
+  blobUrl: string | null;
+}
+
+const PdfViewer: React.FC<Props> = ({ blobUrl }) => {
+  if (!blobUrl) return null;
+  return <iframe src={blobUrl} title="pdf" className="w-full h-full border" />;
+};
+
+export default PdfViewer;
+

--- a/apps/frontend/src/pages/EditorPage.tsx
+++ b/apps/frontend/src/pages/EditorPage.tsx
@@ -3,12 +3,13 @@ import * as Y from 'yjs';
 import CodeMirror from '../components/CodeMirror';
 import { useProject } from '../hooks/useProject';
 import Spinner from '../components/Spinner';
+import PdfViewer from '../components/PdfViewer';
 import { logDebug } from '../debug';
 
 const EditorPage: React.FC = () => {
   const { token, api, gatewayWS } = useProject();
   const [ytext, setYtext] = useState<Y.Text | null>(null);
-  const [pdfUrl, setPdfUrl] = useState<string>('');
+  const [pdfUrl, setPdfUrl] = useState<string | null>(null);
   const [status, setStatus] = useState<'idle' | 'running'>('idle');
 
   const handleReady = useCallback((text: Y.Text) => {
@@ -104,7 +105,7 @@ const EditorPage: React.FC = () => {
       </div>
       {/* Right pane: PDF */}
       <div className="w-1/2 h-full min-h-0 p-2">
-        <iframe src={pdfUrl} title="pdf" className="w-full h-full border" />
+        <PdfViewer blobUrl={pdfUrl} />
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary
- bring back PdfViewer component and render iframe only when blob ready
- initialize pdfUrl as null to avoid blank iframe on load

## Testing
- `npm --prefix apps/frontend run lint`
- `npm --prefix apps/frontend run typecheck`
- `npm --prefix apps/frontend run test`
- `npm --prefix apps/frontend run build`


------
https://chatgpt.com/codex/tasks/task_e_688f83a8eb2c8331a2a785f0a2664069