### PR TITLE
fix: run celery worker in dev

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,7 +26,7 @@ dev-redis:
 	docker run --rm -p 6379:6379 redis:7-alpine
 
 dev-worker:
-	cd backend/compile-service && uv run compile_service.worker:main
+	cd backend/compile-service && uv run celery -A collatex.tasks worker -Q compile -l info
 
 # Always use dev group tools (pytest-xdist, ruff, mypy)
 test:


### PR DESCRIPTION
## Summary
- run celery worker in dev to process compile jobs

## Testing
- `make lint`
- `make typecheck`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_68906997db048331a25d38cc88ee8472