### PR TITLE
Ensure worker runs in dev workflows

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,9 +6,9 @@ up:
 down:
 	docker compose down
 
-# Run both backend and Yjs websocket together
+# Run backend, worker, and Yjs websocket together
 dev:
-	@$(MAKE) -j 2 dev-backend dev-collab
+	@$(MAKE) -j 3 dev-backend dev-worker dev-collab
 
 # Backend only
 dev-backend:

--- a/scripts/dev_local.sh
+++ b/scripts/dev_local.sh
@@ -35,7 +35,7 @@ trap cleanup EXIT INT TERM
 APP_PID=$!
 (
   cd backend/compile-service && \
-  PYTHONPATH="$(pwd)/src" COLLATEX_STATE=redis uv run -m compile_service.worker
+  PYTHONPATH="$(pwd)/src" COLLATEX_STATE=redis uv run celery -A collatex.tasks worker -Q compile -l info
 ) &
 WORKER_PID=$!
 npm --prefix apps/collab_gateway run dev &


### PR DESCRIPTION
## Summary
- run backend, worker, and collab gateway together when using `make dev`
- switch local dev script to Celery worker so compile jobs are processed

## Testing
- `make lint`
- `make typecheck`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_6890ee7f30408331896d0f040c85de36