### PR TITLE
Allow localhost CORS and test

### DIFF
--- a/backend/compile-service/src/compile_service/app/main.py
+++ b/backend/compile-service/src/compile_service/app/main.py
@@ -64,14 +64,23 @@ app = FastAPI(title='CollaTeX Compile Service', version='0.1.0', lifespan=lifesp
 app.mount('/metrics', make_asgi_app())
 
 
-origins = os.getenv('COLLATEX_ALLOWED_ORIGINS', 'http://localhost:5173').split(',')
-app.add_middleware(
-    CORSMiddleware,
-    allow_origins=origins,
-    allow_credentials=True,
-    allow_methods=['*'],
-    allow_headers=['*'],
-)
+allowed_origins = os.getenv('COLLATEX_ALLOWED_ORIGINS')
+if allowed_origins:
+    app.add_middleware(
+        CORSMiddleware,
+        allow_origins=allowed_origins.split(','),
+        allow_credentials=True,
+        allow_methods=['*'],
+        allow_headers=['*'],
+    )
+else:
+    app.add_middleware(
+        CORSMiddleware,
+        allow_origin_regex=r'^https?://(localhost|127\.0\.0\.1)(:\d+)?$',
+        allow_credentials=True,
+        allow_methods=['*'],
+        allow_headers=['*'],
+    )
 
 
 class CompileRequest(BaseModel):

--- a/backend/compile-service/tests/test_cors.py
+++ b/backend/compile-service/tests/test_cors.py
@@ -49,3 +49,23 @@ def test_preflight_forbidden(cors_app):
             },
         )
         assert r.status_code in {400, 403}
+
+
+def test_preflight_localhost_regex(monkeypatch):
+    monkeypatch.setenv('COLLATEX_STATE', 'memory')
+    monkeypatch.delenv('COLLATEX_ALLOWED_ORIGINS', raising=False)
+    importlib.reload(state)
+    import compile_service.app.main as main
+    importlib.reload(main)
+    with TestClient(main.app) as client:
+        r = client.options(
+            '/projects',
+            headers={
+                'Origin': 'http://127.0.0.1:3000',
+                'Access-Control-Request-Method': 'POST',
+            },
+        )
+        assert r.status_code in {200, 204}
+        assert (
+            r.headers['access-control-allow-origin'] == 'http://127.0.0.1:3000'
+        )


### PR DESCRIPTION
## Summary
- allow any localhost/127.0.0.1 origin via regex when COLLATEX_ALLOWED_ORIGINS env is unset
- add regression test to ensure localhost origin is permitted

## Testing
- `make lint`
- `make typecheck`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_689115e78c4c83319e2fad0d947c788a