### PR TITLE
fix: ensure placeholder PDF renders

### DIFF
--- a/backend/compile-service/pyproject.toml
+++ b/backend/compile-service/pyproject.toml
@@ -27,6 +27,7 @@ dev = [
   'fakeredis>=2.24.0',
   'celery==5',
   'asgi_lifespan>=2.1',
+  'pypdf>=5.0',
 ]
 worker = [
   'celery==5'
@@ -58,4 +59,5 @@ dev = [
     "pytest-xdist>=3.8.0",
     "ruff>=0.12.5",
     "asgi_lifespan>=2.1",
+    "pypdf>=5.0",
 ]

--- a/backend/compile-service/static/placeholder.pdf
+++ b/backend/compile-service/static/placeholder.pdf
@@ -1,7 +1,68 @@
-%PDF-1.4
-1 0 obj<</Type/Catalog/Pages 2 0 R>>endobj
-2 0 obj<</Type/Pages/Count 0>>endobj
-trailer<</Root 1 0 R>>
+%PDF-1.3
+% ReportLab Generated PDF document http://www.reportlab.com
+1 0 obj
+<<
+/F1 2 0 R
+>>
+endobj
+2 0 obj
+<<
+/BaseFont /Helvetica /Encoding /WinAnsiEncoding /Name /F1 /Subtype /Type1 /Type /Font
+>>
+endobj
+3 0 obj
+<<
+/Contents 7 0 R /MediaBox [ 0 0 595.2756 841.8898 ] /Parent 6 0 R /Resources <<
+/Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]
+>> /Rotate 0 /Trans <<
+
+>> 
+  /Type /Page
+>>
+endobj
+4 0 obj
+<<
+/PageMode /UseNone /Pages 6 0 R /Type /Catalog
+>>
+endobj
+5 0 obj
+<<
+/Author (anonymous) /CreationDate (D:20250806161622+00'00') /Creator (ReportLab PDF Library - www.reportlab.com) /Keywords () /ModDate (D:20250806161622+00'00') /Producer (ReportLab PDF Library - www.reportlab.com) 
+  /Subject (unspecified) /Title (untitled) /Trapped /False
+>>
+endobj
+6 0 obj
+<<
+/Count 1 /Kids [ 3 0 R ] /Type /Pages
+>>
+endobj
+7 0 obj
+<<
+/Filter [ /ASCII85Decode /FlateDecode ] /Length 116
+>>
+stream
+GapQh0E=F,0U\H3T\pNYT^QKk?tc>IP,;W#U1^23ihPEM_?CW4KISi90MjG^2,FS#<R>^1ccJ`e8W?Opa@T'#c,e4&8M/@i#g#sMd/rQ1huWoHiYJp~>endstream
+endobj
+xref
+0 8
+0000000000 65535 f 
+0000000073 00000 n 
+0000000104 00000 n 
+0000000211 00000 n 
+0000000414 00000 n 
+0000000482 00000 n 
+0000000778 00000 n 
+0000000837 00000 n 
+trailer
+<<
+/ID 
+[<0df23466906f28c03d3255008f480257><0df23466906f28c03d3255008f480257>]
+% ReportLab generated PDF document -- digest (http://www.reportlab.com)
+
+/Info 5 0 R
+/Root 4 0 R
+/Size 8
+>>
 startxref
-0
+1043
 %%EOF

--- a/backend/compile-service/tests/test_placeholder_pdf.py
+++ b/backend/compile-service/tests/test_placeholder_pdf.py
@@ -1,0 +1,9 @@
+from pathlib import Path
+
+from pypdf import PdfReader
+
+
+def test_placeholder_has_page() -> None:
+    pdf_path = Path(__file__).resolve().parents[1] / 'static' / 'placeholder.pdf'
+    reader = PdfReader(str(pdf_path))
+    assert len(reader.pages) >= 1


### PR DESCRIPTION
## Summary
- replace zero-page placeholder PDF with a valid single-page document
- add PDF page-count regression test and pypdf dev dependency

## Testing
- `make lint`
- `make typecheck`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_68937ecde7b08331990c9ff6d99955d5