### PR TITLE
chore(frontend): relax CSP for dev hot reload

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,6 +122,9 @@ every 100&nbsp;ms to keep proxies happy. Prometheus metrics are exposed at
 ## Live Math Preview
 The editor renders LaTeX directly in the browser via MathJax. Set `VITE_USE_SERVER_COMPILE=true` to restore the legacy server compile flow.
 
+## Security model
+The Vite dev server relaxes the Content Security Policy to permit inline scripts and `eval` for tooling like React Refresh. Production builds remain locked down, relying on the strict CSP defined in `apps/frontend/nginx.conf`.
+
 ## Security TODO
 - Replace the temporary `better-xss` sanitiser with an AST-based policy.
 - Harden the Content Security Policy.

--- a/apps/frontend/vite.config.ts
+++ b/apps/frontend/vite.config.ts
@@ -10,7 +10,10 @@ export default defineConfig({
   },
   server: {
     headers: {
-      'Content-Security-Policy': "default-src 'self'; style-src 'self' 'unsafe-inline'",
+      // Dev-only: allow inline/eval for Vite client & React refresh
+      'Content-Security-Policy':
+        "default-src 'self' 'unsafe-inline' 'unsafe-eval'; " +
+        "style-src 'self' 'unsafe-inline'",
     },
   },
 });


### PR DESCRIPTION
## Summary
- allow inline scripts and `eval` for vite dev server so react refresh works
- document relaxed CSP in development while keeping production strict

## Testing
- `npm --prefix apps/frontend run lint`
- `npm --prefix apps/frontend run typecheck`
- `npm --prefix apps/frontend test -- --run`
- `curl -I http://localhost:5175`


------
https://chatgpt.com/codex/tasks/task_e_6894ce1e06948331a6e7536ab8ef189f