### PR TITLE
Allow API requests through CSP

### DIFF
--- a/apps/frontend/nginx.conf
+++ b/apps/frontend/nginx.conf
@@ -1,1 +1,1 @@
-add_header Content-Security-Policy "default-src 'self'; style-src 'self' 'unsafe-inline'";
+add_header Content-Security-Policy "default-src 'self'; style-src 'self' 'unsafe-inline'; connect-src 'self' http://localhost:8080 ws://localhost:1234";

--- a/apps/frontend/vite.config.ts
+++ b/apps/frontend/vite.config.ts
@@ -2,18 +2,21 @@ import { defineConfig } from 'vite';
 import react from '@vitejs/plugin-react';
 
 const apiOrigin = process.env.VITE_API_ORIGIN || 'http://localhost:8080';
+const wsOrigin = process.env.VITE_WS_URL || 'ws://localhost:1234';
 
 export default defineConfig({
   plugins: [react()],
   define: {
     'process.env.VITE_API_ORIGIN': JSON.stringify(apiOrigin),
+    'process.env.VITE_WS_URL': JSON.stringify(wsOrigin),
   },
   server: {
     headers: {
       // Dev-only: allow inline/eval for Vite client & React refresh
       'Content-Security-Policy':
         "default-src 'self' 'unsafe-inline' 'unsafe-eval'; " +
-        "style-src 'self' 'unsafe-inline'",
+        "style-src 'self' 'unsafe-inline'; " +
+        `connect-src 'self' ${apiOrigin} ${wsOrigin}`,
     },
   },
 });


### PR DESCRIPTION
## Summary
- allow API and WebSocket connections by adding `connect-src` to frontend Content-Security-Policy
- expose WS env var in Vite config

## Testing
- `npm --prefix apps/frontend run lint`
- `npm --prefix apps/frontend run typecheck`
- `npm --prefix apps/frontend test -- --run`
- `make lint`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_6894ea0192488331bccd1f3cc276d34c