### PR TITLE
Allow MathJax SVG data URIs

### DIFF
--- a/apps/frontend/nginx.conf
+++ b/apps/frontend/nginx.conf
@@ -1,1 +1,1 @@
-add_header Content-Security-Policy "default-src 'self'; style-src 'self' 'unsafe-inline'; connect-src 'self' http://localhost:8080 ws://localhost:1234";
+add_header Content-Security-Policy "default-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data:; connect-src 'self' http://localhost:8080 ws://localhost:1234";

--- a/apps/frontend/vite.config.ts
+++ b/apps/frontend/vite.config.ts
@@ -16,6 +16,7 @@ export default defineConfig({
       'Content-Security-Policy':
         "default-src 'self' 'unsafe-inline' 'unsafe-eval'; " +
         "style-src 'self' 'unsafe-inline'; " +
+        "img-src 'self' data:; " +
         `connect-src 'self' ${apiOrigin} ${wsOrigin}`,
     },
   },


### PR DESCRIPTION
## Summary
- allow MathJax SVG output by permitting `data:` images in CSP for dev server and nginx

## Testing
- `npm --prefix apps/frontend run lint`
- `npm --prefix apps/frontend test -- --run`
- `make lint`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_6894eff6b56c83319b5dbacf4410ffa0