### PR TITLE
fix(frontend): correct WebSocket connection URL

### DIFF
--- a/apps/frontend/src/components/CodeMirror.tsx
+++ b/apps/frontend/src/components/CodeMirror.tsx
@@ -27,7 +27,7 @@ const CodeMirror: React.FC<Props> = ({ token, gatewayWS, onReady }) => {
     const ydoc = new Y.Doc();
     let provider: WebsocketProvider | undefined;
     try {
-      provider = new WebsocketProvider(`${gatewayWS}/${token}`, 'document', ydoc);
+      provider = new WebsocketProvider(gatewayWS, token, ydoc);
       logDebug('CodeMirror provider', `${gatewayWS}/${token}`);
     } catch (err) {
       if (window.location.hostname !== 'localhost') {

--- a/apps/frontend/src/ws.ts
+++ b/apps/frontend/src/ws.ts
@@ -3,7 +3,7 @@ import { WebsocketProvider } from 'y-websocket';
 import { WS_URL } from './config';
 import { logDebug } from './debug';
 
-export function connectWs(doc: Y.Doc, url: string = WS_URL) {
-  logDebug('connectWs', url);
-  return new WebsocketProvider(url, 'main', doc);
+export function connectWs(doc: Y.Doc, token: string, url: string = WS_URL) {
+  logDebug('connectWs', `${url}/${token}`);
+  return new WebsocketProvider(url, token, doc);
 }


### PR DESCRIPTION
## Summary
- use token as the y-websocket room and keep gatewayWS as server URL
- adjust helper to log and connect using token

## Testing
- `npm --prefix apps/frontend run lint`
- `npm --prefix apps/frontend run typecheck`
- `npm --prefix apps/frontend test`

------
https://chatgpt.com/codex/tasks/task_e_689506fb2f20833194baecf9764a3c5e