### PR TITLE
frontend: reuse single Y.Doc in CodeMirror

### DIFF
--- a/apps/frontend/src/components/CodeMirror.tsx
+++ b/apps/frontend/src/components/CodeMirror.tsx
@@ -23,9 +23,14 @@ const fillParent = EditorView.theme({
 const CodeMirror: React.FC<Props> = ({ token, gatewayWS, onReady }) => {
   const ref = useRef<HTMLDivElement>(null);
   const viewRef = useRef<EditorView>();
+  const ydocRef = useRef<Y.Doc | (() => Y.Doc)>(() => new Y.Doc());
 
   useEffect(() => {
-    const ydoc = new Y.Doc();
+    const ydoc =
+      typeof ydocRef.current === 'function'
+        ? ydocRef.current()
+        : ydocRef.current;
+    ydocRef.current = ydoc;
     let provider: WebsocketProvider | undefined;
     try {
       provider = new WebsocketProvider(`${gatewayWS}/${token}`, 'document', ydoc);


### PR DESCRIPTION
## Summary
- reuse a persistent Y.Doc via `useRef` in CodeMirror component
- ensure WebsocketProvider and EditorView use stable document
- clean up provider and editor view on unmount

## Testing
- `npm --prefix apps/frontend run lint`
- `npm --prefix apps/frontend run typecheck`
- `npm --prefix apps/frontend test`

------
https://chatgpt.com/codex/tasks/task_e_6896215b6bd0833198bf598bf25bc583