### PR TITLE
Fix WebsocketProvider path and add websocket integration test

### DIFF
--- a/apps/frontend/src/components/CodeMirror.tsx
+++ b/apps/frontend/src/components/CodeMirror.tsx
@@ -23,17 +23,13 @@ const fillParent = EditorView.theme({
 const CodeMirror: React.FC<Props> = ({ token, gatewayWS, onReady }) => {
   const ref = useRef<HTMLDivElement>(null);
   const viewRef = useRef<EditorView>();
-  const ydocRef = useRef<Y.Doc | (() => Y.Doc)>(() => new Y.Doc());
+  const ydocRef = useRef<Y.Doc>(new Y.Doc());
 
   useEffect(() => {
-    const ydoc =
-      typeof ydocRef.current === 'function'
-        ? ydocRef.current()
-        : ydocRef.current;
-    ydocRef.current = ydoc;
+    const ydoc = ydocRef.current;
     let provider: WebsocketProvider | undefined;
     try {
-      provider = new WebsocketProvider(`${gatewayWS}/${token}`, 'document', ydoc);
+      provider = new WebsocketProvider(gatewayWS, token, ydoc);
       logDebug('CodeMirror provider', `${gatewayWS}/${token}`);
     } catch (err) {
       if (window.location.hostname !== 'localhost') {
@@ -47,7 +43,6 @@ const CodeMirror: React.FC<Props> = ({ token, gatewayWS, onReady }) => {
       ytext.insert(0, '\\documentclass{article}\\begin{document}\\end{document}');
     }
     const state = EditorState.create({
-      doc: ytext.toString(),
       extensions: [fillParent, keymap.of(defaultKeymap), latex(), yCollab(ytext, awareness)],
     });
     viewRef.current = new EditorView({ state, parent: ref.current! });

--- a/apps/frontend/tests/editorPage.websocket.test.tsx
+++ b/apps/frontend/tests/editorPage.websocket.test.tsx
@@ -1,0 +1,79 @@
+import { render, fireEvent, waitFor, cleanup } from '@testing-library/react';
+import '@testing-library/jest-dom/vitest';
+import { MemoryRouter, Routes, Route } from 'react-router-dom';
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { Awareness } from 'y-protocols/awareness';
+import * as Y from 'yjs';
+
+// Mock MathJax modules to keep tests light
+vi.mock('mathjax-full/js/mathjax.js', () => ({
+  mathjax: {
+    document: () => ({
+      convert: (s: string) => {
+        const el = document.createElement('svg');
+        el.textContent = s;
+        return el;
+      },
+    }),
+  },
+}));
+vi.mock('mathjax-full/js/input/tex.js', () => ({ TeX: class {} }));
+vi.mock('mathjax-full/js/output/svg.js', () => ({ SVG: class {} }));
+vi.mock('mathjax-full/js/adaptors/browserAdaptor.js', () => ({ browserAdaptor: () => ({}) }));
+vi.mock('mathjax-full/js/handlers/html.js', () => ({ RegisterHTMLHandler: () => {} }));
+
+// Spyable stub for WebsocketProvider
+vi.mock('y-websocket', () => ({
+  WebsocketProvider: vi.fn().mockImplementation(function (
+    this: any,
+    url: string,
+    room: string,
+    doc: Y.Doc,
+  ) {
+    this.url = `${url}/${room}`;
+    this.awareness = new Awareness(doc);
+    this.doc = doc;
+    this.destroy = vi.fn();
+  }),
+}));
+import { WebsocketProvider } from 'y-websocket';
+
+// Lightweight MathJaxPreview
+vi.mock('../src/components/MathJaxPreview', () => {
+  const React = require('react');
+  return {
+    __esModule: true,
+    default: ({ source }: any) => <div data-testid="preview">{source}</div>,
+  };
+});
+
+import EditorPage from '../src/pages/EditorPage';
+
+// Tests
+describe('EditorPage websocket', () => {
+  afterEach(() => {
+    vi.clearAllMocks();
+    cleanup();
+  });
+
+  it('connects to websocket without extra path and updates preview', async () => {
+    const { container, getByTestId } = render(
+      <MemoryRouter initialEntries={['/p/fake']}> 
+        <Routes>
+          <Route path="/p/:token" element={<EditorPage />} />
+        </Routes>
+      </MemoryRouter>,
+    );
+    expect(WebsocketProvider).toHaveBeenCalled();
+    const instanceUrl = (WebsocketProvider as any).mock.instances[0].url as string;
+    expect(instanceUrl.endsWith('/document')).toBe(false);
+
+    const instanceDoc = (WebsocketProvider as any).mock.instances[0].doc as Y.Doc;
+    const text = instanceDoc.getText('document');
+    text.insert(0, '$$a+b=c$$');
+    await waitFor(() =>
+      expect(getByTestId('preview').textContent).toContain('a+b=c'),
+    );
+  });
+});
+


### PR DESCRIPTION
## Summary
- ensure CodeMirror uses a single `Y.Doc` and connects via `new WebsocketProvider(gatewayWS, token, ydoc)`
- rely on `yCollab` for initial document content
- add a websocket test verifying provider URL and live preview updates

## Testing
- `npm --prefix apps/frontend test tests/editorPage.websocket.test.tsx`
- `npm --prefix apps/frontend test -- --run`


------
https://chatgpt.com/codex/tasks/task_e_689632be22c48331b13181e129554f30