### PR TITLE
Handle MathJax errors and improve dev UX

### DIFF
--- a/apps/collab_gateway/src/index.ts
+++ b/apps/collab_gateway/src/index.ts
@@ -65,6 +65,14 @@ export function createServer(): http.Server {
       socket.destroy();
       return;
     }
+    const isProd = process.env.NODE_ENV === 'production';
+    if (!isProd) {
+      wss.handleUpgrade(req, socket, head, (ws) => {
+        setupWSConnection(ws, req);
+        connectionsTotal.labels(token!).inc();
+      });
+      return;
+    }
     const exists = await redis.hGet('collatex:projects', token);
     if (!exists) {
       socket.write('HTTP/1.1 404 Not Found\r\n\r\n');

--- a/apps/frontend/src/components/CodeMirror.tsx
+++ b/apps/frontend/src/components/CodeMirror.tsx
@@ -40,7 +40,7 @@ const CodeMirror: React.FC<Props> = ({ token, gatewayWS, onReady }) => {
     const awareness = provider?.awareness ?? new Awareness(ydoc);
     const ytext = ydoc.getText('document');
     if (ytext.length === 0) {
-      ytext.insert(0, '\\documentclass{article}\\begin{document}\\end{document}');
+      ytext.insert(0, 'Type math like \\(e^{i\\pi}+1=0\\) or $$\\int_0^1 x^2\\,dx$$');
     }
     const state = EditorState.create({
       extensions: [fillParent, keymap.of(defaultKeymap), latex(), yCollab(ytext, awareness)],

--- a/apps/frontend/src/components/MathJaxPreview.tsx
+++ b/apps/frontend/src/components/MathJaxPreview.tsx
@@ -48,13 +48,22 @@ const MathJaxPreview: React.FC<Props> = ({ source }) => {
       const container = containerRef.current!;
       const clean = sanitize(source);
       container.innerHTML = '';
-      if (!clean.trim()) {
-        container.textContent = 'Start typing…';
-      } else {
-        const node = doc.convert(clean, { display: false });
-        container.appendChild(node as unknown as Node);
+      const trimmed = clean.trim();
+      if (!trimmed) {
+        container.textContent =
+          'Type TeX math like \\(e^{i\\pi}+1=0\\) or $$\\int_0^1 x^2\\,dx$$';
+        rafRef.current = null;
+        return;
       }
-      rafRef.current = null;
+      try {
+        const isDisplay = clean.includes('$$') || clean.includes('\\[');
+        const node = doc.convert(clean, { display: isDisplay });
+        container.appendChild(node as unknown as Node);
+      } catch (e) {
+        container.textContent = 'TeX error: ' + (e as Error).message;
+      } finally {
+        rafRef.current = null;
+      }
     });
   }
 

--- a/apps/frontend/src/pages/EditorPage.tsx
+++ b/apps/frontend/src/pages/EditorPage.tsx
@@ -23,7 +23,10 @@ const EditorPage: React.FC = () => {
   const handleReady = useCallback(
     (text: Y.Text) => {
       logDebug('editor ready');
-      const observer = () => scheduleRender(text);
+      const observer = () => {
+        logDebug('ytext changed');
+        scheduleRender(text);
+      };
       text.observeDeep(observer);
       unsubRef.current = () => text.unobserveDeep(observer);
 

--- a/apps/frontend/tests/mathjaxPreview.test.tsx
+++ b/apps/frontend/tests/mathjaxPreview.test.tsx
@@ -49,7 +49,9 @@ describe('MathJaxPreview', () => {
     const { container } = render(<MathJaxPreview source="" />);
     await vi.runAllTimersAsync();
     await waitFor(() =>
-      expect(container.textContent).toContain('Start typing…'),
+      expect(container.textContent).toContain(
+        'Type TeX math like \\(e^{i\\pi}+1=0\\) or $$\\int_0^1 x^2\\,dx$$',
+      ),
     );
   });
 });


### PR DESCRIPTION
## Summary
- render MathJax preview in display mode when needed and show errors or placeholder when input is empty
- seed collaborative editor with MathJax sample text and log Y.Text updates
- allow dev connections without Redis token lookup in collab gateway

## Testing
- `npm --prefix apps/frontend run lint`
- `npm --prefix apps/frontend test` *(fails: none; tests pass)*
- `npm --prefix apps/collab_gateway run lint`
- `npx --prefix apps/collab_gateway jest --runTestsByPath apps/collab_gateway/tests/server.test.ts` *(fails: missing semicolon in test)*

------
https://chatgpt.com/codex/tasks/task_e_68970d4884148331926c5fcab657f694