### PR TITLE
fix: ensure preview updates on local edits

### DIFF
--- a/apps/frontend/src/components/CodeMirror.tsx
+++ b/apps/frontend/src/components/CodeMirror.tsx
@@ -43,7 +43,15 @@ const CodeMirror: React.FC<Props> = ({ token, gatewayWS, onReady }) => {
       ytext.insert(0, 'Type math like \\(e^{i\\pi}+1=0\\) or $$\\int_0^1 x^2\\,dx$$');
     }
     const state = EditorState.create({
-      extensions: [fillParent, keymap.of(defaultKeymap), latex(), yCollab(ytext, awareness)],
+      extensions: [
+        fillParent,
+        keymap.of(defaultKeymap),
+        latex(),
+        yCollab(ytext, awareness),
+        EditorView.updateListener.of((update) => {
+          if (update.docChanged) onReady?.(ytext);
+        }),
+      ],
     });
     viewRef.current = new EditorView({ state, parent: ref.current! });
     logDebug('CodeMirror ready');

--- a/apps/frontend/src/pages/EditorPage.tsx
+++ b/apps/frontend/src/pages/EditorPage.tsx
@@ -27,8 +27,8 @@ const EditorPage: React.FC = () => {
         logDebug('ytext changed');
         scheduleRender(text);
       };
-      text.observeDeep(observer);
-      unsubRef.current = () => text.unobserveDeep(observer);
+      text.observe(observer);
+      unsubRef.current = () => text.unobserve(observer);
 
       setTexStr(text.toString());
       scheduleRender(text);


### PR DESCRIPTION
## Summary
- observe Y.Text changes with `observe`/`unobserve` in EditorPage
- add CodeMirror update listener to trigger preview when doc changes

## Testing
- `npm --prefix apps/frontend run lint`
- `npm --prefix apps/frontend run typecheck`
- `npm --prefix apps/frontend test`

------
https://chatgpt.com/codex/tasks/task_e_689711f601d8833184e378213aba7e63