### PR TITLE
feat(frontend): render multiple math blocks and seed text

### DIFF
--- a/apps/frontend/src/components/CodeMirror.tsx
+++ b/apps/frontend/src/components/CodeMirror.tsx
@@ -38,21 +38,22 @@ const CodeMirror: React.FC<Props> = ({ token, gatewayWS, onReady }) => {
       logDebug('CodeMirror provider failed');
     }
     const awareness = provider?.awareness ?? new Awareness(ydoc);
-    const ytext = ydoc.getText('document');
-    if (ytext.length === 0) {
-      ytext.insert(0, 'Type math like \\(e^{i\\pi}+1=0\\) or $$\\int_0^1 x^2\\,dx$$');
-    }
-    const state = EditorState.create({
-      extensions: [
-        fillParent,
-        keymap.of(defaultKeymap),
-        latex(),
-        yCollab(ytext, awareness),
-        EditorView.updateListener.of((update) => {
-          if (update.docChanged) onReady?.(ytext);
-        }),
-      ],
-    });
+      const ytext = ydoc.getText('document');
+      if (ytext.length === 0) {
+        ytext.insert(0, 'Type math like \\(e^{i\\pi}+1=0\\) or $$\\int_0^1 x^2\\,dx$$');
+      }
+      const state = EditorState.create({
+        doc: ytext.toString(),
+        extensions: [
+          fillParent,
+          keymap.of(defaultKeymap),
+          latex(),
+          yCollab(ytext, awareness),
+          EditorView.updateListener.of((update) => {
+            if (update.docChanged) onReady?.(ytext);
+          }),
+        ],
+      });
     viewRef.current = new EditorView({ state, parent: ref.current! });
     logDebug('CodeMirror ready');
     onReady?.(ytext);


### PR DESCRIPTION
## Summary
- tokenize MathJax preview input to interleave prose and math blocks in order
- initialize CodeMirror with Yjs doc so seed text appears immediately

## Testing
- `npm --prefix apps/frontend run lint`
- `npm --prefix apps/frontend run typecheck`
- `cd apps/frontend && npm test -- --run`
- `make lint`
- `make typecheck`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_6897241815808331b16ce30529ab88cf