### PR TITLE
feat(frontend): preserve newlines in MathJax preview

### DIFF
--- a/apps/frontend/src/components/MathJaxPreview.tsx
+++ b/apps/frontend/src/components/MathJaxPreview.tsx
@@ -124,7 +124,12 @@ const MathJaxPreview: React.FC<Props> = ({ source }) => {
     };
   }, [source, ready]);
 
-  return <div ref={containerRef} className="p-2 overflow-auto h-full" />;
+  return (
+    <div
+      ref={containerRef}
+      className="p-2 overflow-auto h-full whitespace-pre-wrap"
+    />
+  );
 };
 
 export default MathJaxPreview;

--- a/apps/frontend/src/index.css
+++ b/apps/frontend/src/index.css
@@ -10,3 +10,5 @@ html, body, #root {
 .cm-editor { height: 100%; display: flex; flex-direction: column; }
 .cm-scroller { flex: 1 1 auto; overflow: auto; }
 .cm-content { white-space: pre; caret-color: currentColor; }
+
+.mjx-display { margin: 0.5rem 0; }


### PR DESCRIPTION
## Summary
- ensure MathJax preview respects newline characters
- add margin around display math blocks for readability

## Testing
- `npm --prefix apps/frontend run lint`
- `npm --prefix apps/frontend run typecheck`
- `npm --prefix apps/frontend run test -- --run`


------
https://chatgpt.com/codex/tasks/task_e_6897284af8708331a69bca2afb2fa364