### PR TITLE
chore: make tests non-interactive

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,2 @@
+fund=false
+audit=false

--- a/README.md
+++ b/README.md
@@ -39,6 +39,16 @@ Tasks:
 - Load testing for WebSocket
 - Frontend E2E test script
 
+### Running tests
+
+Run all JavaScript test suites with:
+
+```bash
+npm test
+```
+
+This command executes Vitest and Jest in CI mode so no interactive watchers or prompts block automated runs.
+
 ## 6) Infra Agent
 Goal: Local and CI infrastructure
 Tasks:

--- a/apps/collab_gateway/package.json
+++ b/apps/collab_gateway/package.json
@@ -7,7 +7,7 @@
     "build": "tsc",
     "start": "node dist/index.js",
     "dev": "ts-node-dev --respawn src/index.ts",
-    "test": "jest",
+    "test": "cross-env CI=1 jest --watchAll=false --runInBand --colors",
     "lint": "eslint \"src/**/*.ts\" \"tests/**/*.ts\" --max-warnings=0"
   },
   "dependencies": {

--- a/apps/frontend/package.json
+++ b/apps/frontend/package.json
@@ -6,7 +6,7 @@
     "dev": "vite",
     "build": "vite build",
     "lint": "eslint \"src/**/*.{ts,tsx}\" --max-warnings=0",
-    "test": "vitest",
+    "test": "cross-env CI=1 vitest run --reporter=basic",
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,10 @@
       "workspaces": [
         "apps/collab_gateway",
         "apps/frontend"
-      ]
+      ],
+      "devDependencies": {
+        "cross-env": "^7.0.3"
+      }
     },
     "apps/collab_gateway": {
       "version": "0.1.0",
@@ -5237,6 +5240,25 @@
       "resolved": "https://registry.npmjs.org/crelt/-/crelt-1.0.6.tgz",
       "integrity": "sha512-VQ2MBenTq1fWZUH9DJNGti7kKv6EeAuYr3cLwxUWhIu1baTaXh4Ib5W2CqHVqib4/MqbYGJqiL3Zb8GJZr3l4g==",
       "license": "MIT"
+    },
+    "node_modules/cross-env": {
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/cross-env/-/cross-env-7.0.3.tgz",
+      "integrity": "sha512-+/HKd6EgcQCJGh2PSjZuUitQBQynKor4wrFbRg4DtAgS1aWO+gU52xpH7M9ScGgXSYmAVS9bIJ8EzuaGw0oNAw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cross-spawn": "^7.0.1"
+      },
+      "bin": {
+        "cross-env": "src/bin/cross-env.js",
+        "cross-env-shell": "src/bin/cross-env-shell.js"
+      },
+      "engines": {
+        "node": ">=10.14",
+        "npm": ">=6",
+        "yarn": ">=1"
+      }
     },
     "node_modules/cross-spawn": {
       "version": "7.0.6",

--- a/package.json
+++ b/package.json
@@ -4,5 +4,14 @@
   "workspaces": [
     "apps/collab_gateway",
     "apps/frontend"
-  ]
+  ],
+  "scripts": {
+    "test": "npm run -s test:frontend && npm run -s test:gateway",
+    "test:frontend": "cross-env CI=1 vitest run --reporter=basic",
+    "test:gateway": "cross-env CI=1 jest --watchAll=false --runInBand --colors",
+    "test:ci": "npm run -s test"
+  },
+  "devDependencies": {
+    "cross-env": "^7.0.3"
+  }
 }


### PR DESCRIPTION
## Summary
- add cross-env test scripts so Vitest and Jest run in CI mode without watchers
- document npm test usage and turn off npm funding/audit prompts

## Testing
- `npm test` *(fails: document is not defined, beforeEach is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_689776696d808331bf1ff4e6985aac6a