### PR TITLE
feat(frontend): sync preview with codemirror

### DIFF
--- a/apps/frontend/src/components/MathJaxPreview.tsx
+++ b/apps/frontend/src/components/MathJaxPreview.tsx
@@ -94,6 +94,7 @@ const MathJaxPreview: React.FC<Props> = ({ source, containerRefExternal }) => {
 
   function scheduleRender() {
     if (rafRef.current) return;
+    console.log('scheduleRender source length', source.length);
     rafRef.current = requestAnimationFrame(() => {
       const container = containerRef.current!;
       container.innerHTML = '';

--- a/apps/frontend/src/pages/EditorPage.tsx
+++ b/apps/frontend/src/pages/EditorPage.tsx
@@ -64,7 +64,7 @@ const EditorPage: React.FC = () => {
     (text: Y.Text) => {
       logDebug('editor ready');
       const observer = () => {
-        logDebug('ytext changed');
+        logDebug('ytext changed (Yjs)');
         scheduleRender(text);
       };
       text.observe(observer);
@@ -105,7 +105,20 @@ const EditorPage: React.FC = () => {
             </div>
           )}
           <div className="flex-1 min-h-0 p-2">
-            <CodeMirror token={token} gatewayWS={gatewayWS} onReady={handleReady} />
+            <CodeMirror
+              token={token}
+              gatewayWS={gatewayWS}
+              onReady={handleReady}
+              onChange={text => scheduleRender(text)}
+              onDocChange={value => {
+                // Belt-and-suspenders: update from CodeMirror directly.
+                if (rafRef.current) return;
+                rafRef.current = requestAnimationFrame(() => {
+                  setTexStr(value);
+                  rafRef.current = null;
+                });
+              }}
+            />
           </div>
         </div>
         <div className="w-1/2 h-full min-h-0 p-2">


### PR DESCRIPTION
## Summary
- emit CodeMirror doc updates directly in addition to Yjs changes
- schedule preview updates on local edits via new onDocChange callback
- log MathJax source length when rendering

## Testing
- `npm --prefix apps/frontend run lint`
- `npm --prefix apps/frontend run typecheck`
- `npm test` *(fails: ReferenceError: document is not defined)*


------
https://chatgpt.com/codex/tasks/task_e_68977bb9fbc88331ab9c20f47f3566a0