### PR TITLE
Improve editor preview sync and logging

### DIFF
--- a/apps/frontend/src/components/CodeMirror.tsx
+++ b/apps/frontend/src/components/CodeMirror.tsx
@@ -72,8 +72,10 @@ const CodeMirror: React.FC<Props> = ({ token, gatewayWS, onReady, onChange, onDo
         yCollab(ytext, awareness),
         EditorView.updateListener.of(update => {
           if (update.docChanged) {
+            const val = update.state.doc.toString();
+            console.debug('[debug] CM update docChanged len=', val.length);
             onChange?.(ytext);
-            onDocChange?.(update.state.doc.toString());
+            onDocChange?.(val);
           }
         }),
       ],

--- a/apps/frontend/src/components/MathJaxPreview.tsx
+++ b/apps/frontend/src/components/MathJaxPreview.tsx
@@ -94,7 +94,6 @@ const MathJaxPreview: React.FC<Props> = ({ source, containerRefExternal }) => {
 
   function scheduleRender() {
     if (rafRef.current) return;
-    console.log('scheduleRender source length', source.length);
     rafRef.current = requestAnimationFrame(() => {
       const container = containerRef.current!;
       container.innerHTML = '';
@@ -105,7 +104,7 @@ const MathJaxPreview: React.FC<Props> = ({ source, containerRefExternal }) => {
         return;
       }
       if (!mjRef.current || typeof mjRef.current.doc.convert !== 'function') {
-        container.textContent = 'MathJax failed to initialize. Reload the page.';
+        container.textContent = 'MathJax failed: doc.convert missing';
         rafRef.current = null;
         return;
       }
@@ -134,6 +133,7 @@ const MathJaxPreview: React.FC<Props> = ({ source, containerRefExternal }) => {
 
   useEffect(() => {
     if (!ready) return;
+    console.debug('[debug] MathJaxPreview render source len=', source.length, 'ready=', ready);
     scheduleRender();
     return () => {
       if (rafRef.current !== null) {


### PR DESCRIPTION
## Summary
- emit debug and doc-string on CodeMirror updates
- update EditorPage preview state immediately, logging Yjs and CodeMirror changes
- add MathJax render debug and explicit error when doc.convert is missing

## Testing
- `npm --prefix apps/frontend run lint`
- `npm --prefix apps/frontend run typecheck`
- `cd apps/frontend && CI=1 npx vitest run --reporter=basic`

------
https://chatgpt.com/codex/tasks/task_e_68977e1e51f083318c2c03dd52dcb310