### PR TITLE
fix: stop CodeMirror from re-initializing on render

### DIFF
--- a/apps/frontend/src/pages/EditorPage.tsx
+++ b/apps/frontend/src/pages/EditorPage.tsx
@@ -66,6 +66,11 @@ const EditorPage: React.FC = () => {
     [],
   );
 
+  const handleDocChange = useCallback((value: string) => {
+    logDebug('onDocChange (CM path) len=', value.length);
+    setTexStr(value);
+  }, []);
+
   useEffect(() => {
     return () => {
       unsubRef.current?.();
@@ -100,10 +105,7 @@ const EditorPage: React.FC = () => {
                 // Optional extra: log Yjs local changes if they do arrive
                 logDebug('onChange (Yjs path) len=', text.toString().length);
               }}
-              onDocChange={value => {
-                logDebug('onDocChange (CM path) len=', value.length);
-                setTexStr(value);
-              }}
+              onDocChange={handleDocChange}
             />
           </div>
         </div>


### PR DESCRIPTION
## Summary
- preserve the same CodeMirror instance across renders by storing callback props in refs and removing them from effect deps
- memoize editor page callbacks

## Testing
- `ESLINT_USE_FLAT_CONFIG=false npm --prefix apps/frontend run lint`
- `npm --prefix apps/frontend run typecheck`
- `CI=1 npx --prefix apps/frontend vitest run --reporter=basic` *(fails: Error: Failed to load url supertest; ReferenceError: document is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_6897810cce84833186cfa210bc06b859