### PR TITLE
refactor: use MathJax v3 pipeline

### DIFF
--- a/apps/frontend/tests/editorPage.websocket.test.tsx
+++ b/apps/frontend/tests/editorPage.websocket.test.tsx
@@ -34,6 +34,7 @@ vi.mock('y-websocket', () => ({
     this.awareness = new Awareness(doc);
     this.doc = doc;
     this.destroy = vi.fn();
+    this.on = vi.fn();
   }),
 }));
 import { WebsocketProvider } from 'y-websocket';


### PR DESCRIPTION
## Summary
- render MathJax using v3 synchronous pipeline and log methods in dev
- add mocks for new MathJax pipeline and WebsocketProvider.on in tests

## Testing
- `npm --prefix apps/frontend run lint`
- `npm --prefix apps/frontend run typecheck`
- `npm --prefix apps/frontend test`

------
https://chatgpt.com/codex/tasks/task_e_689792aef3cc8331acd20a0e4f4a604a