### PR TITLE
fix(frontend): render display math inline

### DIFF
--- a/apps/frontend/src/index.css
+++ b/apps/frontend/src/index.css
@@ -12,3 +12,8 @@ html, body, #root {
 .cm-content { white-space: pre; caret-color: currentColor; }
 
 .mjx-display { margin: 0.5rem 0; }
+/* Force display math ($$...$$) to flow inline instead of breaking to a new line */
+.mjx-display {
+  display: inline;
+  margin: 0 0.25em; /* small horizontal spacing */
+}


### PR DESCRIPTION
## Summary
- keep MathJax `$$...$$` display math inline so it doesn't break text flow

## Testing
- `make lint`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_68979674672c83318615fc4b6a891a79