### PR TITLE
chore: render MathJax display math inline

### DIFF
--- a/apps/frontend/src/index.css
+++ b/apps/frontend/src/index.css
@@ -11,9 +11,20 @@ html, body, #root {
 .cm-scroller { flex: 1 1 auto; overflow: auto; }
 .cm-content { white-space: pre; caret-color: currentColor; }
 
-.mjx-display { margin: 0.5rem 0; }
-/* Force display math ($$...$$) to flow inline instead of breaking to a new line */
-.mjx-display {
-  display: inline;
-  margin: 0 0.25em; /* small horizontal spacing */
+/* MathJax: keep display math inline when scanning for $$...$$ */
+mjx-container[jax="SVG"][display="true"] {
+  display: inline;          /* or inline-block */
+  margin: 0 0.25em;         /* small spacing */
+  text-align: inherit;      /* cancel center alignment */
+  line-height: inherit;     /* align with surrounding text line height */
 }
+mjx-container[jax="SVG"] svg {
+  overflow: visible;        /* avoid clipping tall math when inline */
+}
+/* Optional CHTML output override:
+mjx-container[jax="CHTML"][display="true"] {
+  display: inline;
+  margin: 0 0.25em;
+  text-align: inherit;
+}
+*/


### PR DESCRIPTION
## Summary
- remove obsolete `.mjx-display` overrides
- force MathJax SVG display containers to render inline

## Testing
- `npm --prefix apps/frontend run lint` *(fails: ESLint couldn't find an eslint.config file)*
- `npm --prefix apps/frontend test` *(fails: cross-env: not found)*
- `npm --prefix apps/frontend run typecheck` *(fails: Cannot find type definition file for 'vite/client')*

------
https://chatgpt.com/codex/tasks/task_e_68979966dfc083319816a392ca1b6d7e