### PR TITLE
Normalize whitespace around display math

### DIFF
--- a/apps/frontend/src/components/MathJaxPreview.tsx
+++ b/apps/frontend/src/components/MathJaxPreview.tsx
@@ -98,6 +98,20 @@ const MathJaxPreview: React.FC<Props> = ({ source, containerRefExternal }) => {
         html.getMetrics(); // compute sizes based on container
         html.typeset(); // generate SVG/CHTML
         html.updateDocument(); // push results into the DOM
+        // Normalize whitespace around display math that MathJax wraps with newline text nodes.
+        const displays = container.querySelectorAll('mjx-container[display="true"]');
+        displays.forEach((node) => {
+          const prev = node.previousSibling;
+          if (prev && prev.nodeType === Node.TEXT_NODE) {
+            // collapse trailing whitespace before the math to a single space
+            prev.nodeValue = prev.nodeValue.replace(/\s+$/u, ' ');
+          }
+          const next = node.nextSibling;
+          if (next && next.nodeType === Node.TEXT_NODE) {
+            // collapse leading whitespace after the math to a single space
+            next.nodeValue = next.nodeValue.replace(/^\s+/u, ' ');
+          }
+        });
       } catch (e) {
         container.textContent = 'TeX error: ' + (e as Error).message;
       }


### PR DESCRIPTION
## Summary
- trim whitespace around MathJax display elements after typesetting

## Testing
- `npm --prefix apps/frontend run lint` *(fails: ESLint couldn't find an eslint.config file)*
- `npm --prefix apps/frontend run typecheck` *(fails: Cannot find type definition file for 'vite/client')*
- `CI=1 npx --prefix apps/frontend vitest run --reporter=basic` *(fails: missing packages such as 'react/jsx-dev-runtime')*

------
https://chatgpt.com/codex/tasks/task_e_6897a74e92a48331b63b63d759c7c2b6