### PR TITLE
Treat $$ as inline math and simplify MathJax styles

### DIFF
--- a/apps/frontend/src/components/MathJaxPreview.tsx
+++ b/apps/frontend/src/components/MathJaxPreview.tsx
@@ -33,8 +33,8 @@ const MathJaxPreview: React.FC<Props> = ({ source, containerRefExternal }) => {
       RegisterHTMLHandler(adaptor);
       const tex = new TeX({
         packages: ['base', 'ams'],
-        inlineMath: [['$', '$'], ['\\(', '\\)']],
-        displayMath: [['$$', '$$'], ['\\[', '\\]']],
+        inlineMath: [['$', '$'], ['\\(', '\\)'], ['$$', '$$']], // treat $$ as inline
+        displayMath: [['\\[', '\\]']], // only \[...\] is display
         processEscapes: true,
         processEnvironments: true,
       });
@@ -98,22 +98,6 @@ const MathJaxPreview: React.FC<Props> = ({ source, containerRefExternal }) => {
         html.getMetrics(); // compute sizes based on container
         html.typeset(); // generate SVG/CHTML
         html.updateDocument(); // push results into the DOM
-        // Normalize whitespace around display math that MathJax wraps with newline text nodes.
-        const displays = container.querySelectorAll('mjx-container[display="true"]');
-        displays.forEach((node) => {
-          const prev = node.previousSibling;
-          if (prev && prev.nodeType === Node.TEXT_NODE) {
-            const text = prev as Text;
-            // collapse trailing whitespace before the math to a single space
-            text.data = text.data.replace(/\s+$/u, ' ');
-          }
-          const next = node.nextSibling;
-          if (next && next.nodeType === Node.TEXT_NODE) {
-            const text = next as Text;
-            // collapse leading whitespace after the math to a single space
-            text.data = text.data.replace(/^\s+/u, ' ');
-          }
-        });
       } catch (e) {
         container.textContent = 'TeX error: ' + (e as Error).message;
       }

--- a/apps/frontend/src/index.css
+++ b/apps/frontend/src/index.css
@@ -11,20 +11,10 @@ html, body, #root {
 .cm-scroller { flex: 1 1 auto; overflow: auto; }
 .cm-content { white-space: pre; caret-color: currentColor; }
 
-/* MathJax: keep display math inline when scanning for $$...$$ */
-mjx-container[jax="SVG"][display="true"] {
-  display: inline;          /* or inline-block */
-  margin: 0 0.25em;         /* small spacing */
-  text-align: inherit;      /* cancel center alignment */
-  line-height: inherit;     /* align with surrounding text line height */
+mjx-container[jax="SVG"] {
+  margin: 0 0.25em;         /* subtle spacing around inline math */
 }
+
 mjx-container[jax="SVG"] svg {
   overflow: visible;        /* avoid clipping tall math when inline */
 }
-/* Optional CHTML output override:
-mjx-container[jax="CHTML"][display="true"] {
-  display: inline;
-  margin: 0 0.25em;
-  text-align: inherit;
-}
-*/


### PR DESCRIPTION
## Summary
- Render `$$...$$` as inline math and drop display normalization in MathJaxPreview
- Remove old display-math CSS overrides and add subtle inline spacing

## Testing
- `npm --prefix apps/frontend run lint`
- `npm --prefix apps/frontend run typecheck`
- `npm test` *(fails: ReferenceError: document is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_6897b7cbf9f8833199e7be2f824245aa