### PR TITLE
fix: allow API origin in CSP

### DIFF
--- a/apps/frontend/nginx.conf
+++ b/apps/frontend/nginx.conf
@@ -1,4 +1,4 @@
-add_header Content-Security-Policy "default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval'; style-src 'self' 'unsafe-inline'; img-src 'self' data:; connect-src 'self' http://localhost:8080 ws://localhost:1234";
+add_header Content-Security-Policy "default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval'; style-src 'self' 'unsafe-inline'; img-src 'self' data:; connect-src 'self' http://localhost:1234 http://localhost:8080 ws://localhost:1234";
 
 types {
   application/wasm wasm;

--- a/apps/frontend/vite.config.ts
+++ b/apps/frontend/vite.config.ts
@@ -20,7 +20,7 @@ export default defineConfig({
         "style-src 'self' 'unsafe-inline'; " +
         "img-src 'self' data:; " +
         "script-src 'self' 'unsafe-inline' 'unsafe-eval'; " +
-        `connect-src 'self' ${apiOrigin} ${compileOrigin} ${wsOrigin} /latexwasm`,
+        `connect-src 'self' ${apiOrigin} ${compileOrigin} ${wsOrigin}`,
     },
   },
 });


### PR DESCRIPTION
## Summary
- remove invalid `/latexwasm` entry from Vite dev Content-Security-Policy
- allow frontend to connect to API origin in nginx CSP

## Testing
- `make lint`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_689884920fec83319488d74297b49409