### PR TITLE
fix: allow collab gateway in dev CSP

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -7,5 +7,5 @@ MAX_UPLOAD_BYTES=2097152
 REDIS_URL=redis://redis:6379/0
 
 # Frontend
-VITE_API_ORIGIN=http://localhost:8080
+VITE_API_ORIGIN=http://localhost:1234
 COLLAB_WS_URL=ws://localhost:1234

--- a/apps/frontend/vite.config.ts
+++ b/apps/frontend/vite.config.ts
@@ -5,6 +5,10 @@ const apiOrigin = process.env.VITE_API_ORIGIN || 'http://localhost:1234';
 const compileOrigin = process.env.VITE_COMPILE_ORIGIN || 'http://localhost:8080';
 const wsOrigin = process.env.VITE_WS_URL || 'ws://localhost:1234';
 
+const connectSrc = Array.from(
+  new Set(["'self'", apiOrigin, compileOrigin, wsOrigin]),
+).join(' ');
+
 export default defineConfig({
   plugins: [react()],
   define: {
@@ -20,7 +24,7 @@ export default defineConfig({
         "style-src 'self' 'unsafe-inline'; " +
         "img-src 'self' data:; " +
         "script-src 'self' 'unsafe-inline' 'unsafe-eval'; " +
-        `connect-src 'self' ${apiOrigin} ${compileOrigin} ${wsOrigin}`,
+        `connect-src ${connectSrc}`,
     },
   },
 });


### PR DESCRIPTION
## Summary
- ensure Vite dev server CSP allows calls to the gateway API
- correct `.env.example` default API origin

## Testing
- `npm --prefix apps/frontend run lint` *(fails: ESLint couldn't find a config file)*
- `npm --prefix apps/frontend run typecheck` *(fails: Cannot find type definition file for 'vite/client')*
- `npm --prefix apps/frontend test` *(fails: cross-env not found)*
- `make lint`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_6898a5b7fa3c83319e60118f1d939d17