### PR TITLE
fix: include API origin in dev CSP

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -7,5 +7,6 @@ MAX_UPLOAD_BYTES=2097152
 REDIS_URL=redis://redis:6379/0
 
 # Frontend
-VITE_API_ORIGIN=http://localhost:8080
-COLLAB_WS_URL=ws://localhost:1234
+VITE_API_ORIGIN=http://localhost:1234
+VITE_COMPILE_ORIGIN=http://localhost:8080
+VITE_WS_URL=ws://localhost:1234

--- a/apps/frontend/vite.config.ts
+++ b/apps/frontend/vite.config.ts
@@ -1,26 +1,24 @@
-import { defineConfig } from 'vite';
+import { defineConfig, loadEnv } from 'vite';
 import react from '@vitejs/plugin-react';
 
-const apiOrigin = process.env.VITE_API_ORIGIN || 'http://localhost:1234';
-const compileOrigin = process.env.VITE_COMPILE_ORIGIN || 'http://localhost:8080';
-const wsOrigin = process.env.VITE_WS_URL || 'ws://localhost:1234';
+export default defineConfig(({ mode }) => {
+  const env = loadEnv(mode, process.cwd(), '');
+  const apiOrigin = env.VITE_API_ORIGIN || 'http://localhost:1234';
+  const compileOrigin = env.VITE_COMPILE_ORIGIN || 'http://localhost:8080';
+  const wsOrigin = env.VITE_WS_URL || 'ws://localhost:1234';
 
-export default defineConfig({
-  plugins: [react()],
-  define: {
-    'process.env.VITE_API_ORIGIN': JSON.stringify(apiOrigin),
-    'process.env.VITE_COMPILE_ORIGIN': JSON.stringify(compileOrigin),
-    'process.env.VITE_WS_URL': JSON.stringify(wsOrigin),
-  },
-  server: {
-    headers: {
-      // Dev-only: allow inline/eval for Vite client & React refresh
-      'Content-Security-Policy':
-        "default-src 'self'; " +
-        "style-src 'self' 'unsafe-inline'; " +
-        "img-src 'self' data:; " +
-        "script-src 'self' 'unsafe-inline' 'unsafe-eval'; " +
-        `connect-src 'self' ${apiOrigin} ${compileOrigin} ${wsOrigin}`,
+  return {
+    plugins: [react()],
+    server: {
+      headers: {
+        // Dev-only: allow inline/eval for Vite client & React refresh
+        'Content-Security-Policy':
+          "default-src 'self'; " +
+          "style-src 'self' 'unsafe-inline'; " +
+          "img-src 'self' data:; " +
+          "script-src 'self' 'unsafe-inline' 'unsafe-eval'; " +
+          `connect-src 'self' ${apiOrigin} ${compileOrigin} ${wsOrigin}`,
+      },
     },
-  },
+  };
 });


### PR DESCRIPTION
## Summary
- ensure Vite dev server loads env vars and allows API origin in CSP
- align `.env.example` with current frontend env vars

## Testing
- `npm run lint` (apps/frontend)
- `npm run typecheck` (apps/frontend)
- `CI=1 npx vitest run --reporter=basic` (apps/frontend)


------
https://chatgpt.com/codex/tasks/task_e_6898a5b7fa3c83319e60118f1d939d17