### PR TITLE
refactor: modernize editor layout

### DIFF
--- a/apps/frontend/src/components/AppShell.tsx
+++ b/apps/frontend/src/components/AppShell.tsx
@@ -1,16 +1,19 @@
 import { ThemeToggle } from './ThemeToggle'
 
-export default function AppShell({children}:{children:React.ReactNode}) {
+export default function AppShell({ children }: { children: React.ReactNode }) {
   return (
-    <div className='min-h-screen bg-surface dark:bg-surface-dark text-neutral-900 dark:text-neutral-100 noise'>
+    <div className='min-h-screen-dvh grid grid-rows-[auto,1fr,auto] bg-neutral-50 dark:bg-[#0b0d12] text-neutral-900 dark:text-neutral-100 noise'>
       <header className='sticky top-0 z-50 border-b border-black/5 dark:border-white/5 bg-white/70 dark:bg-black/30 backdrop-blur supports-[backdrop-filter]:bg-white/60'>
-        <div className='max-w-screen-2xl mx-auto flex items-center gap-3 px-4 py-3'>
-          <div className='font-semibold tracking-tight'>CollaTeX</div>
-          <div className='ml-auto flex items-center gap-2'><ThemeToggle/></div>
+        <div className='max-w-screen-2xl mx-auto h-[var(--header-h)] flex items-center gap-3 px-4'>
+          <div className='text-lg font-semibold tracking-tight'>CollaTeX</div>
+          <div className='ml-auto flex items-center gap-2'><ThemeToggle /></div>
         </div>
-        <div className='h-px bg-gradient-to-r from-brand-400 via-brand-500 to-brand-400 animate-[pulse_6s_ease-in-out_infinite]' />
+        <div className='h-1 bg-gradient-to-r from-brand-400 via-brand-500 to-brand-400 animate-[pulse_6s_ease-in-out_infinite]' />
       </header>
-      <main className='max-w-screen-2xl mx-auto p-4'>{children}</main>
+      <main className='min-h-0 max-w-screen-2xl w-full mx-auto p-4'>{children}</main>
+      <footer className='border-t border-black/5 dark:border-white/5 text-xs text-neutral-500 dark:text-neutral-400 px-4 py-2'>
+        © {new Date().getFullYear()} CollaTeX
+      </footer>
     </div>
   )
 }

--- a/apps/frontend/src/components/CodeMirror.tsx
+++ b/apps/frontend/src/components/CodeMirror.tsx
@@ -20,7 +20,8 @@ interface Props {
 
 const fillParent = EditorView.theme({
   '&': { height: '100%' },
-  '.cm-scroller': { overflow: 'auto' },
+  '.cm-editor': { height: '100%' },
+  '.cm-scroller': { height: '100%', overflow: 'auto' },
 });
 
 const SEED_HINT = 'Type TeX math like \\(e^{i\\pi}+1=0\\) or $$\\int_0^1 x^2\\,dx$$';

--- a/apps/frontend/src/components/PdfViewer.tsx
+++ b/apps/frontend/src/components/PdfViewer.tsx
@@ -6,7 +6,7 @@ interface Props {
 
 const PdfViewer: React.FC<Props> = ({ blobUrl }) => {
   if (!blobUrl) return null;
-  return <iframe src={blobUrl} title="pdf" className="w-full h-full border" />;
+  return <iframe src={blobUrl} title="pdf" className="w-full h-full" />;
 };
 
 export default PdfViewer;

--- a/apps/frontend/src/features/editor/EditorLayout.tsx
+++ b/apps/frontend/src/features/editor/EditorLayout.tsx
@@ -1,17 +1,25 @@
 export default function EditorLayout() {
   return (
-    <div className='grid grid-cols-12 gap-4'>
-      <aside className='col-span-3 xl:col-span-2'>
-        <div className='rounded-xl border shadow-soft bg-surface dark:bg-[#111319] p-3 h-[calc(100vh-140px)] overflow-auto'>
-          {/* Project tree + actions */}
-        </div>
+    <div className='grid grid-cols-12 gap-4 h-[calc(100dvh-var(--header-h)-2rem)] min-h-0'>
+      <aside className='col-span-3 xl:col-span-2 min-h-0 h-full rounded-xl border shadow-sm overflow-auto bg-gradient-to-b from-white to-neutral-50 dark:from-[#10131a] dark:to-[#0c0f14] p-3'>
+        {/* Project tree + actions */}
       </aside>
-      <section className='col-span-9 xl:col-span-10 grid grid-cols-12 gap-4'>
-        <div className='col-span-6 rounded-xl border overflow-hidden bg-surface dark:bg-[#0c0f14]'>
-          {/* CodeMirror editor */}
+      <section className='col-span-9 xl:col-span-10 grid grid-cols-12 gap-4 min-h-0'>
+        <div className='col-span-6 flex flex-col rounded-xl border shadow-sm overflow-hidden bg-gradient-to-b from-white to-neutral-50 dark:from-[#10131a] dark:to-[#0c0f14] min-h-0'>
+          <div className='bg-white/60 dark:bg-white/10 border-b border-black/5 dark:border-white/10 backdrop-blur px-2 py-1 flex items-center gap-1'>
+            {/* Editor toolbar */}
+          </div>
+          <div className='flex-1 min-h-0'>
+            {/* CodeMirror editor */}
+          </div>
         </div>
-        <div className='col-span-6 rounded-xl border bg-surface dark:bg-[#0c0f14] flex flex-col'>
-          {/* PDF header + iframe + log drawer */}
+        <div className='col-span-6 flex flex-col rounded-xl border shadow-sm overflow-hidden bg-gradient-to-b from-white to-neutral-50 dark:from-[#10131a] dark:to-[#0c0f14] min-h-0'>
+          <div className='bg-white/60 dark:bg-white/10 border-b border-black/5 dark:border-white/10 backdrop-blur px-2 py-1 flex items-center gap-1'>
+            {/* Preview toolbar */}
+          </div>
+          <div className='flex-1 min-h-0 overflow-auto'>
+            {/* PDF header + iframe + log drawer */}
+          </div>
         </div>
       </section>
     </div>

--- a/apps/frontend/src/styles/globals.css
+++ b/apps/frontend/src/styles/globals.css
@@ -7,13 +7,18 @@
 html, body, #root {
   height: 100%;
 }
+:root {
+  --header-h: 56px;
+}
+.min-h-screen-dvh { min-height: 100dvh; }
+.min-h-0 { min-height: 0; }
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
 
 /* Minimal CodeMirror 6 fallback layout to ensure editability */
 .cm-editor { height: 100%; display: flex; flex-direction: column; }
-.cm-scroller { flex: 1 1 auto; overflow: auto; }
+.cm-scroller { height: 100%; flex: 1 1 auto; overflow: auto; }
 .cm-content { white-space: pre; caret-color: currentColor; }
 
 mjx-container[jax="SVG"] {
@@ -141,4 +146,4 @@ mjx-container[jax="SVG"] svg {
     @apply bg-background text-foreground;
   }
 }
-.noise::before{content:'';position:fixed;inset:0;pointer-events:none;opacity:.04;background-image:url('data:image/svg+xml;...');}
+.noise::before{content:'';position:fixed;inset:0;pointer-events:none;opacity:.04;mix-blend-mode:overlay;background-image:url('data:image/svg+xml;...');}


### PR DESCRIPTION
## Summary
- Introduce full-height utility classes and header height variable in global styles
- Refactor AppShell into a modern grid layout with sticky glass header, gradient accent, and footer
- Implement flexible editor grid with rounded panels and toolbars, ensuring CodeMirror and PDF viewer fill available space

## Testing
- `npm --prefix apps/frontend run lint` *(fails: Could not resolve tailwindcss)*
- `npm --prefix apps/frontend run typecheck`
- `npm --prefix apps/frontend test`

------
https://chatgpt.com/codex/tasks/task_e_6898b68bf8148331a1e2e52c5e3c02d4