### PR TITLE
Fix PDF export failure for OKLCH colors

### DIFF
--- a/apps/frontend/package.json
+++ b/apps/frontend/package.json
@@ -41,6 +41,7 @@
     "yjs": "^13.6.12"
   },
   "devDependencies": {
+    "@csstools/postcss-oklab-function": "^4.0.10",
     "@tailwindcss/forms": "^0.5.10",
     "@tailwindcss/postcss": "^4.1.11",
     "@tailwindcss/typography": "^0.5.16",
@@ -56,6 +57,7 @@
     "eslint-plugin-react": "^7.33.2",
     "jsdom": "^26.1.0",
     "postcss": "^8.5.6",
+    "postcss-lab-function": "^7.0.10",
     "prettier": "^3.2.5",
     "tailwind-merge": "^3.3.1",
     "tailwindcss": "^4.1.11",

--- a/apps/frontend/postcss.config.js
+++ b/apps/frontend/postcss.config.js
@@ -1,6 +1,8 @@
 export default {
   plugins: {
     '@tailwindcss/postcss': {},
+    '@csstools/postcss-oklab-function': { preserve: false },
+    'postcss-lab-function': { preserve: false },
     autoprefixer: {},
   },
 };

--- a/apps/frontend/src/tectonic.d.ts
+++ b/apps/frontend/src/tectonic.d.ts
@@ -1,0 +1,4 @@
+declare module '/tectonic/tectonic_init.js' {
+  const init: (wasmPath: string) => Promise<unknown>;
+  export default init;
+}

--- a/apps/frontend/src/workers/wasm-tectonic.worker.ts
+++ b/apps/frontend/src/workers/wasm-tectonic.worker.ts
@@ -1,3 +1,4 @@
+// @ts-expect-error - provided by runtime bundle, no type declarations
 import initTectonic from '/tectonic/tectonic_init.js';
 
 export interface CompileRequest {

--- a/package-lock.json
+++ b/package-lock.json
@@ -72,6 +72,7 @@
         "yjs": "^13.6.12"
       },
       "devDependencies": {
+        "@csstools/postcss-oklab-function": "^4.0.10",
         "@tailwindcss/forms": "^0.5.10",
         "@tailwindcss/postcss": "^4.1.11",
         "@tailwindcss/typography": "^0.5.16",
@@ -87,6 +88,7 @@
         "eslint-plugin-react": "^7.33.2",
         "jsdom": "^26.1.0",
         "postcss": "^8.5.6",
+        "postcss-lab-function": "^7.0.10",
         "prettier": "^3.2.5",
         "tailwind-merge": "^3.3.1",
         "tailwindcss": "^4.1.11",
@@ -670,6 +672,85 @@
       "license": "MIT",
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/@csstools/postcss-oklab-function": {
+      "version": "4.0.10",
+      "resolved": "https://registry.npmjs.org/@csstools/postcss-oklab-function/-/postcss-oklab-function-4.0.10.tgz",
+      "integrity": "sha512-ZzZUTDd0fgNdhv8UUjGCtObPD8LYxMH+MJsW9xlZaWTV8Ppr4PtxlHYNMmF4vVWGl0T6f8tyWAKjoI6vePSgAg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "dependencies": {
+        "@csstools/css-color-parser": "^3.0.10",
+        "@csstools/css-parser-algorithms": "^3.0.5",
+        "@csstools/css-tokenizer": "^3.0.4",
+        "@csstools/postcss-progressive-custom-properties": "^4.1.0",
+        "@csstools/utilities": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "postcss": "^8.4"
+      }
+    },
+    "node_modules/@csstools/postcss-progressive-custom-properties": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@csstools/postcss-progressive-custom-properties/-/postcss-progressive-custom-properties-4.1.0.tgz",
+      "integrity": "sha512-YrkI9dx8U4R8Sz2EJaoeD9fI7s7kmeEBfmO+UURNeL6lQI7VxF6sBE+rSqdCBn4onwqmxFdBU3lTwyYb/lCmxA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "dependencies": {
+        "postcss-value-parser": "^4.2.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "postcss": "^8.4"
+      }
+    },
+    "node_modules/@csstools/utilities": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@csstools/utilities/-/utilities-2.0.0.tgz",
+      "integrity": "sha512-5VdOr0Z71u+Yp3ozOx8T11N703wIFGVRgOWbOZMKgglPJsWA54MRIoMNVMa7shUToIhx5J8vX4sOZgD2XiihiQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "postcss": "^8.4"
       }
     },
     "node_modules/@epic-web/invariant": {
@@ -9177,6 +9258,36 @@
       },
       "engines": {
         "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/postcss-lab-function": {
+      "version": "7.0.10",
+      "resolved": "https://registry.npmjs.org/postcss-lab-function/-/postcss-lab-function-7.0.10.tgz",
+      "integrity": "sha512-tqs6TCEv9tC1Riq6fOzHuHcZyhg4k3gIAMB8GGY/zA1ssGdm6puHMVE7t75aOSoFg7UD2wyrFFhbldiCMyyFTQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "dependencies": {
+        "@csstools/css-color-parser": "^3.0.10",
+        "@csstools/css-parser-algorithms": "^3.0.5",
+        "@csstools/css-tokenizer": "^3.0.4",
+        "@csstools/postcss-progressive-custom-properties": "^4.1.0",
+        "@csstools/utilities": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "postcss": "^8.4"
       }
     },
     "node_modules/postcss-selector-parser": {


### PR DESCRIPTION
## Summary
- add PostCSS plugins to convert Tailwind OKLCH colors to RGB for html2canvas
- declare tectonic worker module so typecheck passes

## Testing
- `make lint`
- `make typecheck`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_6898f42efc0083318127d1e990e9b12e