### PR TITLE
fix: quote theme color paths

### DIFF
--- a/apps/frontend/src/styles/globals.css
+++ b/apps/frontend/src/styles/globals.css
@@ -69,7 +69,7 @@ mjx-container[jax="SVG"] svg {
 
 :root {
   --radius: 12px;
-  --brand: theme(colors.brand.600);
+  --brand: theme('colors.brand.600');
   --background: oklch(1 0 0);
   --foreground: oklch(0.145 0 0);
   --card: oklch(1 0 0);
@@ -77,7 +77,7 @@ mjx-container[jax="SVG"] svg {
   --popover: oklch(1 0 0);
   --popover-foreground: oklch(0.145 0 0);
   --primary: var(--brand);
-  --primary-foreground: theme(colors.white);
+  --primary-foreground: theme('colors.white');
   --secondary: oklch(0.97 0 0);
   --secondary-foreground: oklch(0.205 0 0);
   --muted: oklch(0.97 0 0);
@@ -96,7 +96,7 @@ mjx-container[jax="SVG"] svg {
   --sidebar: oklch(0.985 0 0);
   --sidebar-foreground: oklch(0.145 0 0);
   --sidebar-primary: var(--brand);
-  --sidebar-primary-foreground: theme(colors.white);
+  --sidebar-primary-foreground: theme('colors.white');
   --sidebar-accent: oklch(0.97 0 0);
   --sidebar-accent-foreground: oklch(0.205 0 0);
   --sidebar-border: oklch(0.922 0 0);
@@ -105,7 +105,7 @@ mjx-container[jax="SVG"] svg {
 
 .dark {
   color-scheme: dark;
-  --brand: theme(colors.brand.500);
+  --brand: theme('colors.brand.500');
   --background: oklch(0.145 0 0);
   --foreground: oklch(0.985 0 0);
   --card: oklch(0.205 0 0);
@@ -113,7 +113,7 @@ mjx-container[jax="SVG"] svg {
   --popover: oklch(0.205 0 0);
   --popover-foreground: oklch(0.985 0 0);
   --primary: var(--brand);
-  --primary-foreground: theme(colors.white);
+  --primary-foreground: theme('colors.white');
   --secondary: oklch(0.269 0 0);
   --secondary-foreground: oklch(0.985 0 0);
   --muted: oklch(0.269 0 0);
@@ -132,7 +132,7 @@ mjx-container[jax="SVG"] svg {
   --sidebar: oklch(0.205 0 0);
   --sidebar-foreground: oklch(0.985 0 0);
   --sidebar-primary: var(--brand);
-  --sidebar-primary-foreground: theme(colors.white);
+  --sidebar-primary-foreground: theme('colors.white');
   --sidebar-accent: oklch(0.269 0 0);
   --sidebar-accent-foreground: oklch(0.985 0 0);
   --sidebar-border: oklch(1 0 0 / 10%);


### PR DESCRIPTION
## Summary
- quote `theme()` color paths so Tailwind resolves custom brand color

## Testing
- `make lint`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_689adf1a7edc8331920ae9d1d78ee179