### PR TITLE
refactor(frontend): replace raw colors with design tokens

### DIFF
--- a/apps/frontend/src/components/ui/button.tsx
+++ b/apps/frontend/src/components/ui/button.tsx
@@ -5,7 +5,7 @@ import { cva, type VariantProps } from "class-variance-authority"
 import { cn } from "@/lib/ui"
 
 const buttonVariants = cva(
-  "inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium transition-all disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg:not([class*='size-'])]:size-4 shrink-0 [&_svg]:shrink-0 outline-none focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive",
+  "inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium transition-all active:translate-y-[1px] disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg:not([class*='size-'])]:size-4 shrink-0 [&_svg]:shrink-0 outline-none focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive",
   {
     variants: {
       variant: {

--- a/apps/frontend/src/features/editor/EditorLayout.tsx
+++ b/apps/frontend/src/features/editor/EditorLayout.tsx
@@ -1,20 +1,20 @@
 export default function EditorLayout() {
   return (
     <div className='grid grid-cols-12 gap-4 h-[calc(100dvh-var(--header-h)-2rem)] min-h-0'>
-      <aside className='col-span-3 xl:col-span-2 min-h-0 h-full rounded-xl border shadow-sm overflow-auto bg-gradient-to-b from-white to-neutral-50 dark:from-[#10131a] dark:to-[#0c0f14] p-3'>
+      <aside className='col-span-3 xl:col-span-2 min-h-0 h-full rounded-xl border border-border bg-card shadow-soft overflow-auto p-3'>
         {/* Project tree + actions */}
       </aside>
       <section className='col-span-9 xl:col-span-10 grid grid-cols-12 gap-4 min-h-0'>
-        <div className='col-span-6 flex flex-col rounded-xl border shadow-sm overflow-hidden bg-gradient-to-b from-white to-neutral-50 dark:from-[#10131a] dark:to-[#0c0f14] min-h-0'>
-          <div className='bg-white/60 dark:bg-white/10 border-b border-black/5 dark:border-white/10 backdrop-blur px-2 py-1 flex items-center gap-1'>
+        <div className='col-span-6 flex flex-col rounded-xl border border-border bg-card shadow-soft overflow-hidden min-h-0'>
+          <div className='bg-card/80 backdrop-blur border-b border-border px-2 py-1 flex items-center gap-1'>
             {/* Editor toolbar */}
           </div>
           <div className='flex-1 min-h-0'>
             {/* CodeMirror editor */}
           </div>
         </div>
-        <div className='col-span-6 flex flex-col rounded-xl border shadow-sm overflow-hidden bg-gradient-to-b from-white to-neutral-50 dark:from-[#10131a] dark:to-[#0c0f14] min-h-0'>
-          <div className='bg-white/60 dark:bg-white/10 border-b border-black/5 dark:border-white/10 backdrop-blur px-2 py-1 flex items-center gap-1'>
+        <div className='col-span-6 flex flex-col rounded-xl border border-border bg-card shadow-soft overflow-hidden min-h-0'>
+          <div className='bg-card/80 backdrop-blur border-b border-border px-2 py-1 flex items-center gap-1'>
             {/* Preview toolbar */}
           </div>
           <div className='flex-1 min-h-0 overflow-auto'>

--- a/apps/frontend/src/main.tsx
+++ b/apps/frontend/src/main.tsx
@@ -19,7 +19,7 @@ function AutoCreate() {
       }
     })().catch((e) => console.error('AutoCreate failed', e));
   }, []);
-  return <div className="h-full grid place-items-center text-sm text-gray-500">Creating project…</div>;
+  return <div className="h-full grid place-items-center text-sm text-muted-foreground">Creating project…</div>;
 }
 
 ReactDOM.createRoot(document.getElementById('root') as HTMLElement).render(

--- a/apps/frontend/src/pages/EditorPage.tsx
+++ b/apps/frontend/src/pages/EditorPage.tsx
@@ -156,42 +156,44 @@ const EditorPage: React.FC = () => {
   }, []);
 
   return (
-    <div className="h-screen flex flex-col bg-white">
-      <header className="flex items-center justify-between px-4 py-2 border-b border-gray-200 bg-surface-soft text-gray-800">
+    <div className="h-screen flex flex-col bg-background">
+      <header className="flex items-center justify-between px-4 py-2 border-b border-border bg-card/80 backdrop-blur text-foreground">
         <div className="flex items-baseline gap-3">
           <span className="text-2xl font-semibold tracking-tight">CollaTeX</span>
           <span className="text-sm opacity-80">Realtime LaTeX + MathJax</span>
         </div>
         <div className="flex items-center gap-2 flex-nowrap">
-          <span className={`inline-flex items-center gap-1 text-xs px-2 py-0.5 rounded ${locked ? 'bg-rose-100 text-rose-700' : 'bg-emerald-100 text-emerald-700'}`}>
-            {locked ? <Lock className="w-3 h-3" /> : <Unlock className="w-3 h-3" />}
+          <span className="inline-flex items-center gap-1 text-xs px-2 py-0.5 rounded bg-muted text-muted-foreground">
+            {locked ? <Lock className="size-3 text-destructive" /> : <Unlock className="size-3 text-primary" />}
             {locked ? 'Locked' : 'Unlocked'}
           </span>
-          <span className="inline-flex items-center gap-1 text-xs px-2 py-0.5 rounded bg-brand-100 text-brand-700">
-            <Users className="w-3 h-3" />
+          <span className="inline-flex items-center gap-1 text-xs px-2 py-0.5 rounded bg-accent text-accent-foreground">
+            <Users className="size-3" />
             {viewerCount}
           </span>
-          <Button className="bg-blue-500 hover:bg-blue-600 text-white gap-1" onClick={refreshState}>
-            <RefreshCw className="w-4 h-4" />
+          <Button variant="secondary" size="sm" className="gap-1" onClick={refreshState}>
+            <RefreshCw className="size-4" />
             Refresh
           </Button>
           {ownerKey && (locked ? (
-            <Button className="bg-green-500 hover:bg-green-600 text-white gap-1" onClick={unlockProject}>
-              <Unlock className="w-4 h-4" />
+            <Button variant="secondary" size="sm" className="gap-1" onClick={unlockProject}>
+              <Unlock className="size-4" />
               Unlock
             </Button>
           ) : (
-            <Button className="bg-red-500 hover:bg-red-600 text-white gap-1" onClick={lockProject}>
-              <Lock className="w-4 h-4" />
+            <Button variant="destructive" size="sm" className="gap-1" onClick={lockProject}>
+              <Lock className="size-4" />
               Lock
             </Button>
           ))}
-          <Button className="bg-teal-500 hover:bg-teal-600 text-white gap-1" onClick={handleShare}>
-            <Share2 className="w-4 h-4" />
+          <Button variant="secondary" size="sm" className="gap-1" onClick={handleShare}>
+            <Share2 className="size-4" />
             Share
           </Button>
           <Button
-            className="bg-purple-500 hover:bg-purple-600 text-white gap-1 disabled:opacity-60"
+            variant="default"
+            size="sm"
+            className="gap-1"
             onClick={handleDownloadPdf}
             disabled={compiling}
             aria-busy={compiling}
@@ -200,21 +202,21 @@ const EditorPage: React.FC = () => {
               'Compiling…'
             ) : (
               <>
-                <Download className="w-4 h-4" />
+                <Download className="size-4" />
                 {isServerCompileEnabled ? 'Download PDF' : 'Export PDF'}
               </>
             )}
           </Button>
           {compileLog && (
-            <details className="ml-2 text-xs text-gray-700">
+            <details className="ml-2 text-xs text-muted-foreground">
               <summary>Show LaTeX log</summary>
-              <pre className="max-h-60 overflow-auto whitespace-pre-wrap text-black bg-white/80 p-2 rounded">{compileLog}</pre>
+              <pre className="max-h-60 overflow-auto whitespace-pre-wrap text-foreground bg-card/80 p-2 rounded">{compileLog}</pre>
             </details>
           )}
         </div>
       </header>
-      <main className="flex-1 h-full min-h-0 flex gap-4 p-4 bg-surface-soft">
-        <section className="flex-1 h-full min-h-0 flex flex-col rounded-xl border bg-surface shadow-soft">
+      <main className="flex-1 h-full min-h-0 flex gap-4 p-4 bg-background">
+        <section className="flex-1 h-full min-h-0 flex flex-col rounded-xl border border-border bg-card shadow-soft">
           <div className="flex-1 min-h-0 p-2">
             <CodeMirror
               token={token}
@@ -227,20 +229,20 @@ const EditorPage: React.FC = () => {
             />
           </div>
         </section>
-        <aside className="flex-1 h-full min-h-0 rounded-xl border bg-surface shadow-soft p-2 overflow-auto" ref={previewRef}>
+        <aside className="flex-1 h-full min-h-0 rounded-xl border border-border bg-card shadow-soft p-2 overflow-auto" ref={previewRef}>
           <MathJaxPreview source={texStr.trim() ? texStr : SEED_HINT} />
         </aside>
       </main>
 
-      <footer className="px-4 py-2 border-t border-gray-200 bg-surface-soft text-xs text-gray-800 flex items-center justify-between">
+      <footer className="px-4 py-2 border-t border-border bg-card/80 backdrop-blur text-xs text-foreground flex items-center justify-between">
         <span>© {new Date().getFullYear()} CollaTeX</span>
-        <a className="underline hover:no-underline text-gray-800" href="https://github.com/ikanher/collatex" target="_blank" rel="noreferrer">
+        <a className="underline hover:no-underline" href="https://github.com/ikanher/collatex" target="_blank" rel="noreferrer">
           GitHub
         </a>
       </footer>
 
       {toast && (
-        <div className="fixed bottom-4 left-1/2 -translate-x-1/2 bg-black text-white text-sm px-3 py-1.5 rounded-md shadow">
+        <div className="fixed bottom-4 left-1/2 -translate-x-1/2 bg-foreground text-background text-sm px-3 py-1.5 rounded-md shadow">
           {toast}
         </div>
       )}

--- a/apps/frontend/src/styles/globals.css
+++ b/apps/frontend/src/styles/globals.css
@@ -144,7 +144,7 @@ mjx-container[jax="SVG"] svg {
     @apply border-border outline-ring/50;
   }
   body {
-    @apply bg-background text-foreground;
+    @apply bg-background text-foreground font-sans;
   }
 }
 .noise::before{content:'';position:fixed;inset:0;pointer-events:none;opacity:.04;mix-blend-mode:overlay;background-image:url('data:image/svg+xml;...');}


### PR DESCRIPTION
## Summary
- replace hard-coded colors with design tokens in EditorPage
- unify EditorLayout and main app with token-based backgrounds
- add active translate effect and base font-sans

## Testing
- `make lint`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_689b45103d8c833195b7771c8ba57b02