### PR TITLE
fix: define default fonts for tailwind v4

### DIFF
--- a/apps/frontend/src/styles/globals.css
+++ b/apps/frontend/src/styles/globals.css
@@ -30,6 +30,9 @@ mjx-container[jax="SVG"] svg {
 }
 
 @theme inline {
+  --font-sans: ui-sans-serif, system-ui, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", "Noto Color Emoji";
+  --font-serif: ui-serif, Georgia, Cambria, "Times New Roman", Times, serif;
+  --font-mono: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace;
   --radius-sm: calc(var(--radius) - 4px);
   --radius-md: calc(var(--radius) - 2px);
   --radius-lg: var(--radius);

--- a/apps/frontend/tailwind.config.ts
+++ b/apps/frontend/tailwind.config.ts
@@ -1,9 +1,15 @@
 import type { Config } from 'tailwindcss'
+import defaultTheme from 'tailwindcss/defaultTheme'
 
 export default <Partial<Config>>({
   darkMode: 'class',
   content: ['./index.html', './src/**/*.{ts,tsx}'],
   theme: {
+    fontFamily: {
+      sans: defaultTheme.fontFamily.sans,
+      serif: defaultTheme.fontFamily.serif,
+      mono: defaultTheme.fontFamily.mono,
+    },
     extend: {
       colors: {
         brand: {


### PR DESCRIPTION
## Summary
- ensure Tailwind 4 compiles by defining default font tokens
- configure Tailwind theme to include default font families

## Testing
- `npm run --workspace apps/frontend lint`
- `npm run --workspace apps/frontend typecheck`
- `npm run --workspace apps/frontend test`


------
https://chatgpt.com/codex/tasks/task_e_689b4ba26b3c833190a817f63384d88b