### PR TITLE
feat: add brand color variables

### DIFF
--- a/apps/frontend/src/components/Spinner.tsx
+++ b/apps/frontend/src/components/Spinner.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
 const Spinner: React.FC = () => (
-  <div className="w-4 h-4 border-4 border-blue-500 border-t-transparent rounded-full animate-spin" />
+  <div className="w-4 h-4 border-4 border-primary border-t-transparent rounded-full animate-spin" />
 );
 
 export default Spinner;

--- a/apps/frontend/src/styles/globals.css
+++ b/apps/frontend/src/styles/globals.css
@@ -30,6 +30,16 @@ mjx-container[jax="SVG"] svg {
 }
 
 @theme inline {
+  --color-brand-50:  #eef3ff;
+  --color-brand-100: #dae5ff;
+  --color-brand-200: #b8ceff;
+  --color-brand-300: #90b2ff;
+  --color-brand-400: #6a93ff;
+  --color-brand-500: #3b75ff;
+  --color-brand-600: #2f5ddb;
+  --color-brand-700: #274ab1;
+  --color-brand-800: #213f8f;
+  --color-brand-900: #1e3776;
   --font-sans: ui-sans-serif, system-ui, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", "Noto Color Emoji";
   --font-serif: ui-serif, Georgia, Cambria, "Times New Roman", Times, serif;
   --font-mono: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace;
@@ -72,74 +82,72 @@ mjx-container[jax="SVG"] svg {
 
 :root {
   --radius: 12px;
-  --brand: var(--color-brand-600);
   --background: oklch(1 0 0);
   --foreground: oklch(0.145 0 0);
   --card: oklch(1 0 0);
   --card-foreground: oklch(0.145 0 0);
   --popover: oklch(1 0 0);
   --popover-foreground: oklch(0.145 0 0);
-  --primary: var(--brand);
+  --primary: var(--color-brand-600);
   --primary-foreground: var(--color-white);
-  --secondary: oklch(0.97 0 0);
-  --secondary-foreground: oklch(0.205 0 0);
-  --muted: oklch(0.97 0 0);
-  --muted-foreground: oklch(0.556 0 0);
-  --accent: oklch(0.97 0 0);
-  --accent-foreground: oklch(0.205 0 0);
+  --secondary: oklch(0.97 0.03 240);
+  --secondary-foreground: oklch(0.205 0.05 240);
+  --muted: oklch(0.97 0.02 240);
+  --muted-foreground: oklch(0.556 0.04 240);
+  --accent: var(--color-brand-100);
+  --accent-foreground: var(--color-brand-700);
   --destructive: oklch(0.577 0.245 27.325);
-  --border: oklch(0.922 0 0);
-  --input: oklch(0.922 0 0);
-  --ring: var(--brand);
+  --border: oklch(0.922 0.01 240);
+  --input: oklch(0.922 0.01 240);
+  --ring: var(--color-brand-600);
   --chart-1: oklch(0.646 0.222 41.116);
   --chart-2: oklch(0.6 0.118 184.704);
   --chart-3: oklch(0.398 0.07 227.392);
   --chart-4: oklch(0.828 0.189 84.429);
   --chart-5: oklch(0.769 0.188 70.08);
-  --sidebar: oklch(0.985 0 0);
-  --sidebar-foreground: oklch(0.145 0 0);
-  --sidebar-primary: var(--brand);
+  --sidebar: oklch(0.985 0.01 240);
+  --sidebar-foreground: oklch(0.145 0.02 240);
+  --sidebar-primary: var(--color-brand-700);
   --sidebar-primary-foreground: var(--color-white);
-  --sidebar-accent: oklch(0.97 0 0);
-  --sidebar-accent-foreground: oklch(0.205 0 0);
-  --sidebar-border: oklch(0.922 0 0);
-  --sidebar-ring: var(--brand);
+  --sidebar-accent: var(--color-brand-100);
+  --sidebar-accent-foreground: var(--color-brand-700);
+  --sidebar-border: oklch(0.922 0.01 240);
+  --sidebar-ring: var(--color-brand-600);
 }
 
 .dark {
   color-scheme: dark;
-  --brand: var(--color-brand-500);
   --background: oklch(0.145 0 0);
   --foreground: oklch(0.985 0 0);
   --card: oklch(0.205 0 0);
   --card-foreground: oklch(0.985 0 0);
   --popover: oklch(0.205 0 0);
   --popover-foreground: oklch(0.985 0 0);
-  --primary: var(--brand);
+  --primary: var(--color-brand-500);
   --primary-foreground: var(--color-white);
-  --secondary: oklch(0.269 0 0);
-  --secondary-foreground: oklch(0.985 0 0);
-  --muted: oklch(0.269 0 0);
-  --muted-foreground: oklch(0.708 0 0);
-  --accent: oklch(0.269 0 0);
-  --accent-foreground: oklch(0.985 0 0);
+  --secondary: oklch(0.269 0.04 240);
+  --secondary-foreground: oklch(0.985 0.05 240);
+  --muted: oklch(0.269 0.03 240);
+  --muted-foreground: oklch(0.708 0.05 240);
+  --accent: var(--color-brand-800);
+  --accent-foreground: var(--color-brand-50);
   --destructive: oklch(0.704 0.191 22.216);
-  --border: oklch(1 0 0 / 10%);
-  --input: oklch(1 0 0 / 15%);
-  --ring: var(--brand);
+  --border: oklch(1 0.02 240 / 10%);
+  --input: oklch(1 0.02 240 / 15%);
+  --ring: var(--color-brand-500);
   --chart-1: oklch(0.488 0.243 264.376);
   --chart-2: oklch(0.696 0.17 162.48);
   --chart-3: oklch(0.769 0.188 70.08);
   --chart-4: oklch(0.627 0.265 303.9);
   --chart-5: oklch(0.645 0.246 16.439);
-  --sidebar: oklch(0.205 0 0);
-  --sidebar-foreground: oklch(0.985 0 0);
-  --sidebar-primary: var(--brand);
+  --sidebar: oklch(0.205 0.02 240);
+  --sidebar-foreground: oklch(0.985 0.03 240);
+  --sidebar-primary: var(--color-brand-400);
   --sidebar-primary-foreground: var(--color-white);
-  --sidebar-accent: oklch(0.269 0 0);
-  --sidebar-accent-foreground: oklch(0.985 0 0);
-  --sidebar-border: oklch(1 0 0 / 10%);
-  --sidebar-ring: var(--brand);
+  --sidebar-accent: var(--color-brand-800);
+  --sidebar-accent-foreground: var(--color-brand-50);
+  --sidebar-border: oklch(1 0.02 240 / 10%);
+  --sidebar-ring: var(--color-brand-500);
 }
 
 @layer base {


### PR DESCRIPTION
## Summary
- define brand color CSS variables
- map primary, ring, sidebar tokens to brand palette and add saturation to other tokens
- use semantic border color for spinner

## Testing
- `make lint`
- `make typecheck`
- `CI=1 npx vitest run --reporter=basic` (apps/collab_gateway)
- `CI=1 npx vitest run --reporter=basic` (apps/frontend)


------
https://chatgpt.com/codex/tasks/task_e_689b5210d3188331981026c3c4bc02ef