### PR TITLE
feat: enforce project locking

### DIFF
--- a/apps/frontend/src/pages/EditorPage.tsx
+++ b/apps/frontend/src/pages/EditorPage.tsx
@@ -40,6 +40,12 @@ const EditorPage: React.FC = () => {
     if (token) refreshState();
   }, [token]);
 
+  useEffect(() => {
+    if (!token) return;
+    const id = setInterval(refreshState, 5000);
+    return () => clearInterval(id);
+  }, [token]);
+
   async function lockProject() {
     const res = await fetch(`${API_URL}/projects/${token}/lock`, {
       method: 'POST',
@@ -48,6 +54,7 @@ const EditorPage: React.FC = () => {
     });
     if (res.ok) {
       setLocked(true);
+      refreshState();
     } else {
       /* toast error */
     }
@@ -60,6 +67,7 @@ const EditorPage: React.FC = () => {
     });
     if (res.ok) {
       setLocked(false);
+      refreshState();
     } else {
       await res.json().catch(() => ({}));
       // show 409 w/ message "active recently" to user


### PR DESCRIPTION
## Summary
- enforce project lock in websocket layer
- poll project lock status on editor page

## Testing
- `make lint` *(fails: ESLint couldn't find an eslint.config)*
- `make test` *(fails: cross-env: not found)*

------
https://chatgpt.com/codex/tasks/task_e_689b89b8f0cc833192e1a0027a6d94a6