### PR TITLE
Stop reconnect loop when project locked

### DIFF
--- a/apps/frontend/src/components/CodeMirror.tsx
+++ b/apps/frontend/src/components/CodeMirror.tsx
@@ -8,6 +8,7 @@ import * as Y from 'yjs';
 import { WebsocketProvider } from 'y-websocket';
 import { Awareness } from 'y-protocols/awareness';
 import { logDebug } from '../debug';
+import { connectWs } from '../ws';
 
 interface Props {
   token: string;
@@ -62,7 +63,7 @@ const CodeMirror: React.FC<Props> = ({ token, gatewayWS, onReady, onChange, onDo
     const ydoc = ydocRef.current;
     let provider: WebsocketProvider | undefined;
     try {
-      provider = new WebsocketProvider(gatewayWS, token, ydoc);
+      provider = connectWs(ydoc, token, gatewayWS);
       logDebug('CodeMirror provider', `${gatewayWS}/${token}`);
     } catch (err) {
       if (window.location.hostname !== 'localhost') {

--- a/apps/frontend/src/ws.ts
+++ b/apps/frontend/src/ws.ts
@@ -5,5 +5,11 @@ import { logDebug } from './debug';
 
 export function connectWs(doc: Y.Doc, token: string, url: string = WS_URL) {
   logDebug('connectWs', `${url}/${token}`);
-  return new WebsocketProvider(url, token, doc);
+  const provider = new WebsocketProvider(url, token, doc);
+  provider.on('connection-close', (event: CloseEvent) => {
+    if (event.code === 1008) {
+      provider.shouldConnect = false;
+    }
+  });
+  return provider;
 }


### PR DESCRIPTION
## Summary
- disable WebSocket reconnection when gateway returns `1008` (locked)
- use shared `connectWs` helper inside CodeMirror to apply the lock-aware provider

## Testing
- `npm run lint --workspace apps/collab_gateway`
- `npm run lint --workspace apps/frontend`
- `npm test --workspace apps/collab_gateway`
- `npm test --workspace apps/frontend` *(fails: Error: Aborting after running 10000 timers)*

------
https://chatgpt.com/codex/tasks/task_e_689b8f824fb08331a671bc79e726f061