### PR TITLE
fix: load tectonic wasm dynamically

### DIFF
--- a/apps/frontend/src/workers/wasm-tectonic.worker.ts
+++ b/apps/frontend/src/workers/wasm-tectonic.worker.ts
@@ -1,5 +1,9 @@
+// Tectonic is loaded at runtime from the public assets folder.
 // @ts-expect-error - provided by runtime bundle, no type declarations
-import initTectonic from '/tectonic/tectonic_init.js';
+const loadTectonic = async () => {
+  const modulePath = '/tectonic/tectonic_init.js';
+  return (await import(/* @vite-ignore */ modulePath)).default;
+};
 
 export interface CompileRequest {
   latex: string;
@@ -16,6 +20,7 @@ export interface CompileResponse {
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 self.onmessage = async (_e: MessageEvent<CompileRequest>) => {
   try {
+    const initTectonic = await loadTectonic();
     const engine = await initTectonic('/tectonic/tectonic.wasm');
     // TODO: wire file system and actual compilation
     engine; // silence unused


### PR DESCRIPTION
## Summary
- load Tectonic WASM initializer via dynamic import so Vite worker build succeeds

## Testing
- `npm --prefix apps/frontend run lint`
- `make test` *(fails: Aborting after running 10000 timers...)*
- `VITE_API_TOKEN=changeme npm --prefix apps/frontend run build`


------
https://chatgpt.com/codex/tasks/task_e_689ca86fc3b88331b3c12696b06e16a8