### PR TITLE
build: separate gateway production tsconfig

### DIFF
--- a/apps/collab_gateway/package.json
+++ b/apps/collab_gateway/package.json
@@ -4,7 +4,7 @@
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "scripts": {
-    "build": "tsc",
+    "build": "tsc -p tsconfig.build.json",
     "start": "node dist/index.js",
     "dev": "ts-node-dev --respawn src/index.ts",
     "test": "cross-env CI=1 vitest run --reporter=basic",

--- a/apps/collab_gateway/tsconfig.build.json
+++ b/apps/collab_gateway/tsconfig.build.json
@@ -1,0 +1,13 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "types": ["node"]
+  },
+  "include": [
+    "src/**/*.ts",
+    "src/types/**/*.d.ts"
+  ],
+  "files": [
+    "src/types/y-websocket.d.ts"
+  ]
+}


### PR DESCRIPTION
## Summary
- create tsconfig.build.json for gateway, excluding tests and vitest globals
- run build with tsc using the new build config

## Testing
- `npm run lint --workspace apps/collab_gateway` *(fails: ESLint couldn't find config)*
- `CI=1 npx --workspace apps/collab_gateway vitest run --reporter=basic` *(fails: Cannot find package 'supertest')*
- `npm run build --workspace apps/collab_gateway` *(fails: Cannot find type definition file for 'node')*

------
https://chatgpt.com/codex/tasks/task_e_689caeff7cf48331a34cf43a0a19350a