### PR TITLE
feat: improve WASM export logging

### DIFF
--- a/apps/frontend/src/components/PdfExportButton.tsx
+++ b/apps/frontend/src/components/PdfExportButton.tsx
@@ -19,9 +19,30 @@ const PdfExportButton: React.FC<Props> = ({ getSource, previewRef }) => {
     if (!previewEl) return;
     setBusy(true);
     setLog('');
+    const enableWasmTex =
+      import.meta.env.VITE_ENABLE_WASM_TEX ?? (import.meta.env.DEV ? 'true' : 'false');
+    const wasmEnabled = enableWasmTex === 'true';
+    console.log(
+      '[Export] WASM compile enabled:',
+      wasmEnabled,
+      '(env:',
+      import.meta.env.VITE_ENABLE_WASM_TEX,
+      ')'
+    );
+    console.log('[Export] Starting export. Using WASM path? ->', wasmEnabled);
+    if (!wasmEnabled) {
+      console.warn(
+        '[Export] Skipping WASM compile due to feature flag or env config. Falling back to screenshot export.'
+      );
+    }
     setStatus('Loading engine…');
     try {
-      const res = await generatePdf({ source: getSource(), previewEl, onStatus: setStatus });
+      const res = await generatePdf({
+        source: getSource(),
+        previewEl,
+        onStatus: setStatus,
+        wasmEnabled,
+      });
       if (res.log) setLog(res.log);
       if (res.blob) {
         const url = URL.createObjectURL(res.blob);

--- a/apps/frontend/src/lib/flags.ts
+++ b/apps/frontend/src/lib/flags.ts
@@ -1,1 +1,7 @@
-export const ENABLE_WASM_TEX = import.meta.env.VITE_ENABLE_WASM_TEX === 'true';
+// Determine whether the WASM TeX path is enabled. Default to true in
+// development builds if the environment variable is undefined so that local
+// developers get the faster WASM experience without additional config.
+const enableWasmTexEnv =
+  import.meta.env.VITE_ENABLE_WASM_TEX ?? (import.meta.env.DEV ? 'true' : 'false');
+
+export const ENABLE_WASM_TEX = enableWasmTexEnv === 'true';

--- a/apps/frontend/src/workers/wasm-tectonic.worker.ts
+++ b/apps/frontend/src/workers/wasm-tectonic.worker.ts
@@ -23,10 +23,18 @@ async function getEngine() {
   enginePromise = (async () => {
     try {
       const t = '/tectonic/tectonic_init.js';
+      console.log('[Worker] Attempting to load Tectonic WASM from /tectonic/tectonic_init.js');
       const initMod = await import(/* @vite-ignore */ t);
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      return await (initMod as any).default('/tectonic/tectonic.wasm');
-    } catch {
+      const engine = await (initMod as any).default('/tectonic/tectonic.wasm');
+      console.log('[Worker] Tectonic engine loaded successfully.');
+      return engine;
+    } catch (e) {
+      console.error('[Worker] Failed to load Tectonic WASM:', e);
+      const msg = e instanceof Error ? e.message : String(e);
+      if (msg.includes('Failed to fetch') || msg.includes('404')) {
+        throw new Error('tectonic_assets_missing');
+      }
       throw new Error('tectonic_unavailable');
     }
   })();
@@ -36,6 +44,7 @@ async function getEngine() {
 
 self.onmessage = async (e: MessageEvent<CompileRequest>) => {
   const logs: string[] = [];
+  console.log('[Worker] Received compile request. Latex length:', e.data.latex.length);
   try {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const engine: any = await getEngine();
@@ -56,8 +65,9 @@ self.onmessage = async (e: MessageEvent<CompileRequest>) => {
     } else {
       self.postMessage({ ok: false, log, error: 'tectonic_unavailable' } as CompileResponse);
     }
-  } catch {
-    self.postMessage({ ok: false, log: logs.join('\n'), error: 'tectonic_unavailable' } as CompileResponse);
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : 'tectonic_unavailable';
+    self.postMessage({ ok: false, log: logs.join('\n'), error: msg } as CompileResponse);
   }
 };
 

--- a/apps/frontend/tests/pdfGenerator.worker.test.ts
+++ b/apps/frontend/tests/pdfGenerator.worker.test.ts
@@ -50,7 +50,7 @@ beforeEach(() => {
 
 describe('generatePdf', () => {
   it('skips fallback when worker returns pdf', async () => {
-    const res = await generatePdf({ source: 'hi', previewEl: document.createElement('div') });
+    const res = await generatePdf({ source: 'hi', previewEl: document.createElement('div'), wasmEnabled: true });
     expect(res.via).toBe('wasm');
     expect(html2canvasMock).not.toHaveBeenCalled();
   });
@@ -62,7 +62,7 @@ describe('generatePdf', () => {
       height: 50,
       toDataURL: () => 'data:image/png;base64,'
     } as unknown as HTMLCanvasElement);
-    const res = await generatePdf({ source: 'hi', previewEl: document.createElement('div') });
+    const res = await generatePdf({ source: 'hi', previewEl: document.createElement('div'), wasmEnabled: true });
     expect(res.via).toBe('canvas');
     expect(html2canvasMock).toHaveBeenCalled();
     expect(res.log).toContain('⚠ Tectonic unavailable, falling back to screenshot export.');


### PR DESCRIPTION
## Summary
- default WASM TeX flag to true in dev
- log export path decisions and worker lifecycle
- surface asset-missing or disabled WASM cases in logs and UI

## Testing
- `npm --prefix apps/frontend run lint`
- `npm --prefix apps/collab_gateway run lint`
- `npm --prefix apps/frontend run typecheck`
- `CI=1 npx --prefix apps/collab_gateway vitest run apps/collab_gateway/tests --reporter=basic`
- `npm --prefix apps/frontend run test`


------
https://chatgpt.com/codex/tasks/task_e_689e3d72c6e8833185edb456c3e9d963