### PR TITLE
fix: load tectonic init via fetch

### DIFF
--- a/apps/frontend/src/tectonic.d.ts
+++ b/apps/frontend/src/tectonic.d.ts
@@ -1,4 +1,0 @@
-declare module '/tectonic/tectonic_init.js' {
-  const init: (wasmPath: string) => Promise<unknown>;
-  export default init;
-}

--- a/apps/frontend/tests/wasm-tectonic.worker.test.ts
+++ b/apps/frontend/tests/wasm-tectonic.worker.test.ts
@@ -2,13 +2,14 @@ import { describe, it, expect, vi } from 'vitest';
 import type { CompileResponse } from '../src/workers/wasm-tectonic.worker';
 
 vi.mock('../src/lib/flags', () => ({ ENABLE_WASM_TEX: true }));
-vi.mock('/tectonic/tectonic_init.js', () => ({
-  default: vi.fn(async () => ({
-    compileLaTeX: () => ({ pdf: new Uint8Array([1]), log: '' }),
-    writeMemFSFile: vi.fn(),
-    setEngineMainFile: vi.fn(),
-  })),
-}));
+vi.stubGlobal(
+  'fetch',
+  vi.fn(async () => ({
+    ok: true,
+    text: async () =>
+      "export default async () => ({ compileLaTeX: () => ({ pdf: new Uint8Array([1]), log: '' }), writeMemFSFile: () => {}, setEngineMainFile: () => {} })",
+  }))
+);
 
 describe('wasm-tectonic worker', () => {
   it('returns pdf bytes from engine', async () => {


### PR DESCRIPTION
## Summary
- load tectonic init script via fetch and data url
- stub fetch in wasm worker test
- drop unused tectonic type declaration

## Testing
- `make lint` *(fails: ESLint couldn't find config)*
- `npm --prefix apps/frontend run lint`
- `make test` *(fails: cross-env: not found)*
- `npm --prefix apps/frontend test`


------
https://chatgpt.com/codex/tasks/task_e_689f3de9bd28833185379f55bf371e48