### PR TITLE
Handle missing Tectonic engine gracefully

### DIFF
--- a/apps/frontend/src/pages/EditorPage.tsx
+++ b/apps/frontend/src/pages/EditorPage.tsx
@@ -142,7 +142,7 @@ const EditorPage: React.FC = () => {
             <Share2 className="size-4" />
             Share
           </Button>
-          <PdfExportButton getSource={() => texStr} previewRef={previewRef} />
+          <PdfExportButton getSource={() => texStr} />
         </div>
       </header>
       <main className="flex-1 h-full min-h-0 flex gap-4 p-4 bg-background">


### PR DESCRIPTION
## Summary
- drop screenshot-based PDF fallback
- show a dialog when the Tectonic engine is unavailable
- update tests for new error handling

## Testing
- `make lint`
- `make typecheck`
- `npm --prefix apps/collab_gateway run test` *(fails: sh: 1: cross-env: not found)*
- `npm --prefix apps/frontend run test`


------
https://chatgpt.com/codex/tasks/task_e_689f40a29c688331b6f15099835958d0