### PR TITLE
Handle missing Tectonic assets in PDF export

### DIFF
--- a/apps/frontend/src/workers/wasm-tectonic.worker.ts
+++ b/apps/frontend/src/workers/wasm-tectonic.worker.ts
@@ -29,6 +29,10 @@ async function getEngine() {
         throw new Error(resp.status === 404 ? 'tectonic_assets_missing' : 'tectonic_unavailable');
       }
       const source = await resp.text();
+      const type = resp.headers.get('content-type') || '';
+      if (!type.includes('javascript') || source.trim().startsWith('Not Found')) {
+        throw new Error('tectonic_assets_missing');
+      }
       const initMod = await import(
         /* @vite-ignore */ `data:text/javascript,${encodeURIComponent(source)}`
       );

--- a/apps/frontend/tests/wasm-tectonic.worker.test.ts
+++ b/apps/frontend/tests/wasm-tectonic.worker.test.ts
@@ -1,18 +1,24 @@
-import { describe, it, expect, vi } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 import type { CompileResponse } from '../src/workers/wasm-tectonic.worker';
 
 vi.mock('../src/lib/flags', () => ({ ENABLE_WASM_TEX: true }));
-vi.stubGlobal(
-  'fetch',
-  vi.fn(async () => ({
-    ok: true,
-    text: async () =>
-      "export default async () => ({ compileLaTeX: () => ({ pdf: new Uint8Array([1]), log: '' }), writeMemFSFile: () => {}, setEngineMainFile: () => {} })",
-  }))
-);
 
 describe('wasm-tectonic worker', () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.restoreAllMocks();
+  });
+
   it('returns pdf bytes from engine', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => ({
+        ok: true,
+        text: async () =>
+          "export default async () => ({ compileLaTeX: () => ({ pdf: new Uint8Array([1]), log: '' }), writeMemFSFile: () => {}, setEngineMainFile: () => {} })",
+        headers: { get: () => 'application/javascript' },
+      }))
+    );
     const messages: CompileResponse[] = [];
     const selfRef: any = { postMessage: (msg: CompileResponse) => messages.push(msg) };
     vi.stubGlobal('self', selfRef);
@@ -20,5 +26,23 @@ describe('wasm-tectonic worker', () => {
     await selfRef.onmessage({ data: { latex: 'hi', engineOpts: {} } });
     expect(messages[0].ok).toBe(true);
     expect(messages[0].pdf?.length).toBeGreaterThan(0);
+  });
+
+  it('reports missing assets on unexpected response', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => ({
+        ok: true,
+        text: async () => 'Not Found',
+        headers: { get: () => 'text/html' },
+      }))
+    );
+    const messages: CompileResponse[] = [];
+    const selfRef: any = { postMessage: (msg: CompileResponse) => messages.push(msg) };
+    vi.stubGlobal('self', selfRef);
+    await import('../src/workers/wasm-tectonic.worker');
+    await selfRef.onmessage({ data: { latex: 'hi', engineOpts: {} } });
+    expect(messages[0].ok).toBe(false);
+    expect(messages[0].error).toBe('tectonic_assets_missing');
   });
 });


### PR DESCRIPTION
## Summary
- Guard against unexpected responses when loading Tectonic WASM assets
- Cover worker asset-missing path with unit tests

## Testing
- `make lint`
- `(cd apps/collab_gateway && CI=1 npx vitest run --reporter=basic)`
- `npm --prefix apps/frontend test`


------
https://chatgpt.com/codex/tasks/task_e_689f4671822483319297ac45821a815e