### PR TITLE
chore: validate tectonic asset download

### DIFF
--- a/scripts/fetch-tectonic-assets.sh
+++ b/scripts/fetch-tectonic-assets.sh
@@ -8,9 +8,27 @@ DEST_TECTONIC="apps/frontend/public/tectonic"
 DEST_BUNDLE="apps/frontend/public/texbundle"
 mkdir -p "$DEST_TECTONIC" "$DEST_BUNDLE"
 
-# Example commands; adjust versions as needed
-curl -L "https://github.com/tectonic-typesetting/tectonic/releases/latest/download/tectonic.wasm" -o "$DEST_TECTONIC/tectonic.wasm"
-curl -L "https://github.com/tectonic-typesetting/tectonic/releases/latest/download/tectonic_init.js" -o "$DEST_TECTONIC/tectonic_init.js"
+ENGINE_URL="https://github.com/tectonic-typesetting/tectonic/releases/latest/download/tectonic.wasm"
+INIT_URL="https://github.com/tectonic-typesetting/tectonic/releases/latest/download/tectonic_init.js"
+
+echo "Downloading Tectonic engine..."
+curl -fL "$ENGINE_URL" -o "$DEST_TECTONIC/tectonic.wasm" || {
+  echo "Failed to download Tectonic WASM engine" >&2
+  exit 1
+}
+
+echo "Downloading Tectonic init script..."
+curl -fL "$INIT_URL" -o "$DEST_TECTONIC/tectonic_init.js" || {
+  echo "Failed to download Tectonic init script" >&2
+  rm -f "$DEST_TECTONIC/tectonic.wasm"
+  exit 1
+}
+
+if grep -q 'Not Found' "$DEST_TECTONIC/tectonic_init.js"; then
+  echo "Tectonic assets not found at provided URLs" >&2
+  rm -f "$DEST_TECTONIC/tectonic.wasm" "$DEST_TECTONIC/tectonic_init.js"
+  exit 1
+fi
 
 # Fetch minimal bundle (placeholder; replace with actual source)
 # curl -L <bundle-url> -o bundle.zip && unzip -o bundle.zip -d "$DEST_BUNDLE" && rm bundle.zip


### PR DESCRIPTION
## Summary
- fail early if Tectonic WASM assets cannot be downloaded

## Testing
- `make lint` *(fails: ESLint couldn't find an eslint.config.js)*
- `make test` *(fails: cross-env: not found)*

------
https://chatgpt.com/codex/tasks/task_e_689f592fb3d08331a1606b81f6331e21