### PR TITLE
fix BusyTeX asset fetcher

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,4 +26,5 @@ var/
 *.pdf
 !backend/compile-service/static/placeholder.pdf
 *.log
-apps/frontend/public/vendor/busytex/
+apps/frontend/public/vendor/busytex/*
+apps/frontend/public/vendor/busytex/.busytex-tag

--- a/README.md
+++ b/README.md
@@ -71,6 +71,9 @@ Fetch the BusyTeX assets once:
 npm run fetch:busytex
 ```
 
+The fetch script automatically resolves and caches the latest BusyTeX release tag
+into `.busytex-tag`. Use `--fresh` to re-resolve.
+
 Large WASM/data files are downloaded into `apps/frontend/public/vendor/busytex/`
 (gitignored).
 

--- a/scripts/fetch_busytex_assets.js
+++ b/scripts/fetch_busytex_assets.js
@@ -3,11 +3,11 @@ const fs = require('fs');
 const path = require('path');
 const https = require('https');
 
-const TAG = 'v2025.01.19';
 const FILES = [
   'busytex_pipeline.js',
   'busytex_worker.js',
   'busytex.wasm',
+  'busytex.js',
   'texlive-basic.js',
   'texlive-basic.data',
   'ubuntu-texlive-latex-extra.js',
@@ -21,30 +21,58 @@ const FILES = [
 const destDir = path.join(__dirname, '..', 'apps', 'frontend', 'public', 'vendor', 'busytex');
 const fresh = process.argv.includes('--fresh');
 const offlineOk = process.argv.includes('--offline-ok');
+const tagCacheFile = path.join(destDir, '.busytex-tag');
+
+function httpHeadOrGet(url) {
+  return new Promise((resolve, reject) => {
+    const req = https.request(url, { method: 'HEAD' }, res => resolve(res));
+    req.on('error', reject);
+    req.end();
+  }).catch(() => new Promise((resolve, reject) => {
+    https.get(url, res => resolve(res)).on('error', reject);
+  }));
+}
+
+async function resolveLatestTag() {
+  await fs.promises.mkdir(destDir, { recursive: true });
+  if (!fresh && fs.existsSync(tagCacheFile)) {
+    const cached = fs.readFileSync(tagCacheFile, 'utf8').trim();
+    if (cached) return cached;
+  }
+  // GitHub latest redirect points to /tag/<TAG>
+  const res = await httpHeadOrGet('https://github.com/busytex/busytex/releases/latest');
+  const location = res.headers.location || res.headers.Location;
+  if (!location) {
+    throw new Error('Could not resolve latest release tag (no redirect Location header)');
+  }
+  const m = location.match(/\/tag\/(.+)$/);
+  if (!m) throw new Error(`Unexpected redirect Location: ${location}`);
+  const tag = m[1];
+  fs.writeFileSync(tagCacheFile, tag, 'utf8');
+  return tag;
+}
 
 function download(url, dest) {
   return new Promise((resolve, reject) => {
-    https
-      .get(url, res => {
-        if (res.statusCode !== 200) {
-          reject(new Error(`GET ${url} failed: ${res.statusCode}`));
-          res.resume();
-          return;
-        }
-        const file = fs.createWriteStream(dest);
-        res.pipe(file);
-        file.on('finish', () => {
-          file.close(err => {
-            if (err) return reject(err);
-            fs.stat(dest, (err2, stats) => {
-              if (err2) return reject(err2);
-              if (stats.size === 0) return reject(new Error(`${dest} empty`));
-              resolve();
-            });
+    https.get(url, res => {
+      if (res.statusCode !== 200) {
+        reject(new Error(`GET ${url} failed: ${res.statusCode}`));
+        res.resume();
+        return;
+      }
+      const file = fs.createWriteStream(dest);
+      res.pipe(file);
+      file.on('finish', () => {
+        file.close(err => {
+          if (err) return reject(err);
+          fs.stat(dest, (err2, stats) => {
+            if (err2) return reject(err2);
+            if (stats.size === 0) return reject(new Error(`${dest} empty`));
+            resolve();
           });
         });
-      })
-      .on('error', reject);
+      });
+    }).on('error', reject);
   });
 }
 
@@ -61,29 +89,37 @@ async function fetchWithRetry(url, dest, retries = 3) {
 }
 
 async function main() {
-  await fs.promises.mkdir(destDir, { recursive: true });
-  const fetched = [];
-  for (const name of FILES) {
-    const dest = path.join(destDir, name);
-    if (!fresh && fs.existsSync(dest) && fs.statSync(dest).size > 0) {
-      continue;
-    }
-    const url = `https://github.com/busytex/busytex/releases/download/${TAG}/${name}`;
-    try {
-      await fetchWithRetry(url, dest, 3);
-      console.log(`fetched ${name}`);
-      fetched.push(name);
-    } catch (err) {
-      console.error(`failed ${name}: ${err.message}`);
-      if (offlineOk) {
-        console.log('offline-ok: skipping BusyTeX asset fetch');
+  try {
+    await fs.promises.mkdir(destDir, { recursive: true });
+    const tag = await resolveLatestTag();
+    const fetched = [];
+    for (const name of FILES) {
+      const dest = path.join(destDir, name);
+      if (!fresh && fs.existsSync(dest) && fs.statSync(dest).size > 0) {
+        continue;
+      }
+      const url = `https://github.com/busytex/busytex/releases/download/${tag}/${name}`;
+      try {
+        await fetchWithRetry(url, dest, 3);
+        console.log(`fetched ${name}`);
+        fetched.push(name);
+      } catch (err) {
+        console.error(`failed ${name}: ${err.message}`);
+        if (offlineOk) {
+          console.log('offline-ok: skipping BusyTeX asset fetch (using any existing local assets)');
+          console.log(`BusyTeX tag (cached): ${tag}`);
+          return;
+        }
+        process.exitCode = 1;
         return;
       }
-      process.exitCode = 1;
-      return;
     }
+    console.log(`BusyTeX tag: ${tag}`);
+    console.log(`BusyTeX assets present: ${FILES.length}, fetched now: ${fetched.length}`);
+  } catch (e) {
+    console.error(e.message || String(e));
+    if (offlineOk) process.exit(0);
+    process.exit(1);
   }
-  console.log(`BusyTeX assets present: ${FILES.length}, fetched: ${fetched.length}`);
 }
-
 main();


### PR DESCRIPTION
## Summary
- resolve BusyTeX latest release tag at runtime and cache it
- ignore BusyTeX vendor assets and cache tag
- document BusyTeX tag cache in README

## Testing
- `npm ci --ignore-scripts`
- `npm test` *(fails: wasmTex.test.ts times out)*
- `node scripts/fetch_busytex_assets.js` *(fails: connect ENETUNREACH 140.82.112.3:443)*
- `ls -lh apps/frontend/public/vendor/busytex`
- `cat apps/frontend/public/vendor/busytex/.busytex-tag` *(fails: No such file or directory)*
- `git diff --name-only --staged | xargs file | grep -Ei "(PDF|ELF|archive|image|wasm|data)"`

------
https://chatgpt.com/codex/tasks/task_e_68a1beaf48c883318262fd2f92266341