### PR TITLE
Fix websocket URL when sending owner key

### DIFF
--- a/apps/frontend/src/ws.ts
+++ b/apps/frontend/src/ws.ts
@@ -9,11 +9,10 @@ export function connectWs(
   url: string = WS_URL,
   ownerKey = '',
 ) {
-  const finalUrl = ownerKey
-    ? `${url}?ownerKey=${encodeURIComponent(ownerKey)}`
-    : url;
-  logDebug('connectWs', `${finalUrl}/${token}`);
-  const provider = new WebsocketProvider(finalUrl, token, doc);
+  logDebug('connectWs', `${url}/${token}`);
+  const provider = new WebsocketProvider(url, token, doc, {
+    params: ownerKey ? { ownerKey } : {},
+  });
   provider.on('connection-close', (event: CloseEvent) => {
     if (event.code === 1008) {
       provider.shouldConnect = false;

--- a/apps/frontend/tests/editorPage.websocket.test.tsx
+++ b/apps/frontend/tests/editorPage.websocket.test.tsx
@@ -29,10 +29,12 @@ vi.mock('y-websocket', () => ({
     url: string,
     room: string,
     doc: Y.Doc,
+    opts?: { params?: Record<string, string> },
   ) {
     this.url = `${url}/${room}`;
     this.awareness = new Awareness(doc);
     this.doc = doc;
+    this.opts = opts;
     this.destroy = vi.fn();
     this.on = vi.fn();
   }),
@@ -82,6 +84,23 @@ describe('EditorPage websocket', () => {
     text.insert(0, '$$a+b=c$$');
     await waitFor(() =>
       expect(getByTestId('preview').textContent).toContain('a+b=c'),
+    );
+  });
+
+  it('sends ownerKey via params when available', () => {
+    localStorage.setItem('collatex:ownerKey:fake', 'secret');
+    render(
+      <MemoryRouter initialEntries={['/p/fake']}>
+        <Routes>
+          <Route path="/p/:token" element={<EditorPage />} />
+        </Routes>
+      </MemoryRouter>,
+    );
+    expect(WebsocketProvider).toHaveBeenCalledWith(
+      expect.any(String),
+      'fake',
+      expect.any(Y.Doc),
+      expect.objectContaining({ params: { ownerKey: 'secret' } }),
     );
   });
 });


### PR DESCRIPTION
## Summary
- send ownerKey via WebsocketProvider params instead of mangling the base URL
- cover ownerKey param handling in websocket test

## Testing
- `npm --prefix apps/collab_gateway test`
- `npm --prefix apps/frontend test`
- `npm --prefix apps/collab_gateway run lint`
- `npm --prefix apps/frontend run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a6101885f08331b16e78fa9983a35d